### PR TITLE
Enabled TLS based access for redis DB in three node setup

### DIFF
--- a/install/Docker/dockerfiles/scripts/redis-entrypointsetup.sh
+++ b/install/Docker/dockerfiles/scripts/redis-entrypointsetup.sh
@@ -39,8 +39,6 @@ function launchmaster() {
   sed -i "s/%replica-announce-ip%/${hostname}/" /redis-master/redis.conf
   sed -i "s/%master-port%/${REDIS_HA_REDIS_SERVICE_PORT}/" /redis-master/redis.conf
 
-  sed -n 871p /redis-master/redis.conf
-  sed -n 874p /redis-master/redis.conf
   redis-server /redis-master/redis.conf --protected-mode no
 }
 

--- a/install/Docker/dockerfiles/scripts/redis-entrypointsetup.sh
+++ b/install/Docker/dockerfiles/scripts/redis-entrypointsetup.sh
@@ -34,6 +34,13 @@ function launchmaster() {
   fi
   bash insert_master_ip_and_default_entries.sh &
   sed -i "s/REDIS_DEFAULT_PASSWORD/${REDIS_DEFAULT_PASSWORD}/" /redis-master/redis.conf
+
+  hostname=$(hostname -f)
+  sed -i "s/%replica-announce-ip%/${hostname}/" /redis-master/redis.conf
+  sed -i "s/%master-port%/${REDIS_HA_REDIS_SERVICE_PORT}/" /redis-master/redis.conf
+
+  sed -n 871p /redis-master/redis.conf
+  sed -n 874p /redis-master/redis.conf
   redis-server /redis-master/redis.conf --protected-mode no
 }
 
@@ -45,16 +52,16 @@ function launchsentinel() {
 
   while true; do
     echo "Trying to connect to Sentinel Service"
-    master=$(redis-cli -h ${REDIS_HA_SENTINEL_SERVICE_HOST} -p ${REDIS_HA_SENTINEL_SERVICE_PORT} --csv SENTINEL get-master-addr-by-name ${REDIS_MASTER_SET} | tr ',' ' ' | cut -d' ' -f1)
+    master=$(redis-cli -h ${REDIS_HA_SENTINEL_SERVICE_HOST} -p ${REDIS_HA_SENTINEL_SERVICE_PORT} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} --csv SENTINEL get-master-addr-by-name ${REDIS_MASTER_SET} | tr ',' ' ' | cut -d' ' -f1)
     if [[ -n ${master} ]]; then
       echo "Connected to Sentinel Service and retrieved Redis Master IP as ${master}"
       master="${master//\"}"
     else
       echo "Unable to connect to Sentinel Service, probably because I am first Sentinel to start. I will try to find STARTUP_MASTER_IP from the redis service"
       if [[ -n ${REDIS_DEFAULT_PASSWORD} ]]; then
-        master=$(redis-cli -a ${REDIS_DEFAULT_PASSWORD} -h ${REDIS_HA_REDIS_SERVICE_HOST} -p ${REDIS_HA_REDIS_SERVICE_PORT} get STARTUP_MASTER_IP)
+        master=$(redis-cli -a ${REDIS_DEFAULT_PASSWORD} -h ${REDIS_HA_REDIS_SERVICE_HOST} -p ${REDIS_HA_REDIS_SERVICE_PORT} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} get STARTUP_MASTER_IP)
       else
-        master=$(redis-cli -h ${REDIS_HA_REDIS_SERVICE_HOST} -p ${REDIS_HA_REDIS_SERVICE_PORT} get STARTUP_MASTER_IP)
+        master=$(redis-cli -h ${REDIS_HA_REDIS_SERVICE_HOST} -p ${REDIS_HA_REDIS_SERVICE_PORT} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} get STARTUP_MASTER_IP)
       fi
       if [[ -n ${master} ]]; then
         echo "Retrieved Redis Master IP as ${master}"
@@ -65,9 +72,9 @@ function launchsentinel() {
       fi
     fi
       if [[ -n ${REDIS_DEFAULT_PASSWORD} ]]; then
-        redis-cli -a ${REDIS_DEFAULT_PASSWORD} -h ${master} INFO
+        redis-cli -a ${REDIS_DEFAULT_PASSWORD} -h ${master} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} INFO
       else
-        redis-cli -h ${master} INFO
+        redis-cli -h ${master} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} INFO
       fi
 
     if [[ "$?" == "0" ]]; then
@@ -79,11 +86,24 @@ function launchsentinel() {
 
   sentinel_conf=sentinel.conf
 
-  echo "sentinel monitor ${REDIS_MASTER_SET} ${master} ${REDIS_HA_REDIS_SERVICE_PORT} ${SENTINEL_QUORUM}" > ${sentinel_conf}
+  hostname=$(hostname -f)
+
+  echo "sentinel resolve-hostnames yes" > ${sentinel_conf}
+  echo "sentinel announce-hostnames yes" >> ${sentinel_conf}
+  echo "sentinel announce-ip ${hostname}" >> ${sentinel_conf}
+  echo "sentinel announce-port ${REDIS_HA_SENTINEL_SERVICE_PORT}" >> ${sentinel_conf}
+  echo "sentinel monitor ${REDIS_MASTER_SET} ${MASTER_HOST_NAME} ${REDIS_HA_REDIS_SERVICE_PORT} ${SENTINEL_QUORUM}" >> ${sentinel_conf}
   echo "sentinel down-after-milliseconds ${REDIS_MASTER_SET} ${DOWN_AFTER_MILLISECONDS}" >> ${sentinel_conf}
   echo "sentinel failover-timeout ${REDIS_MASTER_SET} ${FAILOVER_TIMEOUT}" >> ${sentinel_conf}
   echo "sentinel parallel-syncs ${REDIS_MASTER_SET} ${PARALLEL_SYNCS}" >> ${sentinel_conf}
   echo "bind 0.0.0.0" >> ${sentinel_conf}
+  echo "port 0" >> ${sentinel_conf}
+  echo "tls-port 26379" >> ${sentinel_conf}
+  echo "tls-replication yes" >> ${sentinel_conf}
+  echo "tls-cluster yes" >> ${sentinel_conf}
+  echo "tls-cert-file /etc/odimra_certs/odimra_server.crt" >> ${sentinel_conf}
+  echo "tls-key-file /etc/odimra_certs/odimra_server.key" >> ${sentinel_conf}
+  echo "tls-ca-cert-file /etc/odimra_certs/rootCA.crt" >> ${sentinel_conf}
   if [[ -n ${REDIS_DEFAULT_PASSWORD} ]]; then
     echo "sentinel auth-pass ${REDIS_MASTER_SET} ${REDIS_DEFAULT_PASSWORD}" >> ${sentinel_conf}
   fi
@@ -97,7 +117,7 @@ function launchslave() {
 
   while true; do
     echo "Trying to retrieve the Master IP again, in case of failover master ip would have changed."
-    master=$(redis-cli -h ${REDIS_HA_SENTINEL_SERVICE_HOST} -p ${REDIS_HA_SENTINEL_SERVICE_PORT} --csv SENTINEL get-master-addr-by-name ${REDIS_MASTER_SET} | tr ',' ' ' | cut -d' ' -f1)
+    master=$(redis-cli -h ${REDIS_HA_SENTINEL_SERVICE_HOST} -p ${REDIS_HA_SENTINEL_SERVICE_PORT} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} --csv SENTINEL get-master-addr-by-name ${REDIS_MASTER_SET} | tr ',' ' ' | cut -d' ' -f1)
     if [[ -n ${master} ]]; then
       master="${master//\"}"
     else
@@ -106,9 +126,9 @@ function launchslave() {
       continue
     fi
     if [[ -n ${REDIS_DEFAULT_PASSWORD} ]]; then
-      redis-cli -a ${REDIS_DEFAULT_PASSWORD} -h ${master} INFO
+      redis-cli -a ${REDIS_DEFAULT_PASSWORD} -h ${master} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} INFO
     else
-      redis-cli -h ${master} INFO
+      redis-cli -h ${master} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} INFO
     fi
     if [[ "$?" == "0" ]]; then
       break
@@ -117,9 +137,13 @@ function launchslave() {
     sleep 10
   done
 
+  hostname=$(hostname -f)
   sed -i "s/%master-ip%/${master}/" /redis-slave/redis.conf
   sed -i "s/%master-port%/${REDIS_HA_REDIS_SERVICE_PORT}/" /redis-slave/redis.conf
   sed -i "s/REDIS_DEFAULT_PASSWORD/${REDIS_DEFAULT_PASSWORD}/" /redis-slave/redis.conf
+  sed -i "s/%replica-announce-ip%/${hostname}/" /redis-slave/redis.conf
+  sed -i "s/%replicaof%/${master}/" /redis-slave/redis.conf
+
   redis-server /redis-slave/redis.conf --protected-mode no
 }
 
@@ -128,12 +152,12 @@ function launchslave() {
 function launchredis() {
   echo "Launching Redis instance"
 
+  hostname=$(hostname -f)
   # Loop till I am able to launch slave or master
   while true; do
     # I will check if sentinel is up or not by connecting to it.
     echo "Trying to connect to sentinel, to retireve master's ip"
-    master=$(redis-cli -h ${REDIS_HA_SENTINEL_SERVICE_HOST} -p ${REDIS_HA_SENTINEL_SERVICE_PORT} --csv SENTINEL get-master-addr-by-name ${REDIS_MASTER_SET} | tr ',' ' ' | cut -d' ' -f1)
-
+    master=$(redis-cli -h ${REDIS_HA_SENTINEL_SERVICE_HOST} -p ${REDIS_HA_SENTINEL_SERVICE_PORT} --tls --cert ${TLS_CERT_FILE} --key ${TLS_KEY_FILE} --cacert ${TLS_CA_CERT_FILE} --csv SENTINEL get-master-addr-by-name ${REDIS_MASTER_SET} | tr ',' ' ' | cut -d' ' -f1)
     # Is this instance marked as MASTER, it will matter only when the cluster is starting up for first time.
     if [[ "${MASTER}" == "true" ]]; then
       echo "MASTER is set to true"

--- a/install/Docker/dockerfiles/scripts/redis-master.conf
+++ b/install/Docker/dockerfiles/scripts/redis-master.conf
@@ -859,3 +859,39 @@ tls-key-file /etc/odimra_certs/odimra_server.key
 # of these, and will not implicitly use the system wide configuration.
 #
 tls-ca-cert-file /etc/odimra_certs/rootCA.crt
+# By default, a Redis replica does not attempt to establish a TLS connection
+# with its master.
+#
+# Use the following directive to enable TLS on replication links.
+#
+tls-replication yes
+# By default, the Redis Cluster bus uses a plain TCP connection. To enable
+# TLS for the bus protocol, use the following directive:
+#
+tls-cluster yes
+# A Redis master is able to list the address and port of the attached
+# replicas in different ways. For example the "INFO replication" section
+# offers this information, which is used, among other tools, by
+# Redis Sentinel in order to discover replica instances.
+# Another place where this info is available is in the output of the
+# "ROLE" command of a master.
+#
+# The listed IP address and port normally reported by a replica is
+# obtained in the following way:
+#
+#   IP: The address is auto detected by checking the peer address
+#   of the socket used by the replica to connect with the master.
+#
+#   Port: The port is communicated by the replica during the replication
+#   handshake, and is normally the port that the replica is using to
+#   listen for connections.
+#
+# However when port forwarding or Network Address Translation (NAT) is
+# used, the replica may actually be reachable via different IP and port
+# pairs. The following two options can be used by a replica in order to
+# report to its master a specific set of IP and port, so that both INFO
+# and ROLE will report those values.
+#
+replica-announce-ip %replica-announce-ip%
+replica-announce-port %master-port%
+#

--- a/install/Docker/dockerfiles/scripts/redis-slave.conf
+++ b/install/Docker/dockerfiles/scripts/redis-slave.conf
@@ -859,3 +859,59 @@ tls-key-file /etc/odimra_certs/odimra_server.key
 # of these, and will not implicitly use the system wide configuration.
 #
 tls-ca-cert-file /etc/odimra_certs/rootCA.crt
+# By default, a Redis replica does not attempt to establish a TLS connection
+# with its master.
+#
+# Use the following directive to enable TLS on replication links.
+#
+tls-replication yes
+# By default, the Redis Cluster bus uses a plain TCP connection. To enable
+# TLS for the bus protocol, use the following directive:
+#
+tls-cluster yes
+# A Redis master is able to list the address and port of the attached
+# replicas in different ways. For example the "INFO replication" section
+# offers this information, which is used, among other tools, by
+# Redis Sentinel in order to discover replica instances.
+# Another place where this info is available is in the output of the
+# "ROLE" command of a master.
+#
+# The listed IP address and port normally reported by a replica is
+# obtained in the following way:
+#
+#   IP: The address is auto detected by checking the peer address
+#   of the socket used by the replica to connect with the master.
+#
+#   Port: The port is communicated by the replica during the replication
+#   handshake, and is normally the port that the replica is using to
+#   listen for connections.
+#
+# However when port forwarding or Network Address Translation (NAT) is
+# used, the replica may actually be reachable via different IP and port
+# pairs. The following two options can be used by a replica in order to
+# report to its master a specific set of IP and port, so that both INFO
+# and ROLE will report those values.
+#
+replica-announce-ip %replica-announce-ip%
+replica-announce-port %master-port%
+# Master-Replica replication. Use replicaof to make a Redis instance a copy of
+# another Redis server. A few things to understand ASAP about Redis replication.
+#
+#   +------------------+      +---------------+
+#   |      Master      | ---> |    Replica    |
+#   | (receive writes) |      |  (exact copy) |
+#   +------------------+      +---------------+
+#
+# 1) Redis replication is asynchronous, but you can configure a master to
+#    stop accepting writes if it appears to be not connected with at least
+#    a given number of replicas.
+# 2) Redis replicas are able to perform a partial resynchronization with the
+#    master if the replication link is lost for a relatively small amount of
+#    time. You may want to configure the replication backlog size (see the next
+#    sections of this file) with a sensible value depending on your needs.
+# 3) Replication is automatic and does not need user intervention. After a
+#    network partition replicas automatically try to reconnect to masters
+#    and resynchronize with them.
+#
+replicaof %replicaof% %master-port%
+#

--- a/lib-persistence-manager/persistencemgr/redis.go
+++ b/lib-persistence-manager/persistencemgr/redis.go
@@ -81,10 +81,13 @@ func init() {
 }
 
 func sentinelNewClient(dbConfig *Config) *redisSentinel.SentinelClient {
+	tlsConfig, err := getTLSConfig()
+	if err != nil {
+		log.Error("error while trying to get tls configuration : ", err.Error())
+	}
 	rdb := redisExtCalls.newSentinelClient(&redisSentinel.Options{
-		Addr:     dbConfig.Host + ":" + dbConfig.SentinelPort,
-		Password: "", // no password set
-		DB:       0,  // use default DB
+		Addr:      dbConfig.Host + ":" + dbConfig.SentinelPort,
+		TLSConfig: tlsConfig,
 	})
 	return rdb
 }

--- a/lib-persistence-manager/persistencemgr/redis.go
+++ b/lib-persistence-manager/persistencemgr/redis.go
@@ -87,6 +87,7 @@ func sentinelNewClient(dbConfig *Config) *redisSentinel.SentinelClient {
 	}
 	rdb := redisExtCalls.newSentinelClient(&redisSentinel.Options{
 		Addr:      dbConfig.Host + ":" + dbConfig.SentinelPort,
+		DB:        0, // use default DB
 		TLSConfig: tlsConfig,
 	})
 	return rdb

--- a/odim-controller/helmcharts/redis-ha/templates/redis-ha-inmemory-primary-statefulset.yaml
+++ b/odim-controller/helmcharts/redis-ha/templates/redis-ha-inmemory-primary-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.odimra.namespace }}
   labels:
     app: redis-ha-inmemory
+  annotations:
+    secret.reloader.stakater.com/reload: "odimra-secret"
 spec:
   replicas: 1
   serviceName: redis-ha-inmemory-headless
@@ -22,7 +24,33 @@ spec:
         - name: redis-data
           persistentVolumeClaim:
             claimName: redis-ha-inmemory-data-claim
-
+        - name: odimra-secret
+          secret:
+            secretName: odimra-secret
+            items:
+            - key: rootCAcrt
+              path: rootCA.crt
+              mode: 0444
+            - key: odimra_servercrt
+              path: odimra_server.crt
+              mode: 0444
+            - key: odimra_serverkey
+              path: odimra_server.key
+              mode: 0444
+            - key: odimra_rsapublic
+              path: odimra_rsa.public
+              mode: 0444
+            - key: odimra_rsaprivate
+              path: odimra_rsa.private
+              mode: 0444
+            {{- if eq .Values.odimra.messageBusType "Kafka" }}
+            - key: odimra_kafka_clientcrt
+              path: odimra_kafka_client.crt
+              mode: 0444
+            - key: odimra_kafka_clientkey
+              path: odimra_kafka_client.key
+              mode: 0444
+            {{- end }}
       restartPolicy: Always
       affinity:
         nodeAffinity:
@@ -53,12 +81,22 @@ spec:
           - mountPath: "/redis-data"
             name: redis-data
             readOnly: false
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: MASTER
           value: "true"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-inmemory-primary-0.redis-ha-inmemory-headless.odim.svc.cluster.local"
         - name: REDIS_ONDISK_DB 
           value: "false"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-inmemory.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT
@@ -76,11 +114,23 @@ spec:
         imagePullPolicy: IfNotPresent
 
         ports:
-        - containerPort: 26379 
+        - containerPort: 26379
+
+        volumeMounts:
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: SENTINEL
           value: "true"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-inmemory-primary-0.redis-ha-inmemory-headless.odim.svc.cluster.local"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-inmemory.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT

--- a/odim-controller/helmcharts/redis-ha/templates/redis-ha-inmemory-secondary-statefulset.yaml
+++ b/odim-controller/helmcharts/redis-ha/templates/redis-ha-inmemory-secondary-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.odimra.namespace }}
   labels:
     app: redis-ha-inmemory
+  annotations:
+    secret.reloader.stakater.com/reload: "odimra-secret"
 spec:
   replicas: {{ .Values.odimra.redisSecondayReplicaCount }}
   serviceName: redis-ha-inmemory-headless
@@ -22,7 +24,33 @@ spec:
         - name: redis-data
           persistentVolumeClaim:
             claimName: redis-ha-inmemory-data-claim
-
+        - name: odimra-secret
+          secret:
+            secretName: odimra-secret
+            items:
+            - key: rootCAcrt
+              path: rootCA.crt
+              mode: 0444
+            - key: odimra_servercrt
+              path: odimra_server.crt
+              mode: 0444
+            - key: odimra_serverkey
+              path: odimra_server.key
+              mode: 0444
+            - key: odimra_rsapublic
+              path: odimra_rsa.public
+              mode: 0444
+            - key: odimra_rsaprivate
+              path: odimra_rsa.private
+              mode: 0444
+            {{- if eq .Values.odimra.messageBusType "Kafka" }}
+            - key: odimra_kafka_clientcrt
+              path: odimra_kafka_client.crt
+              mode: 0444
+            - key: odimra_kafka_clientkey
+              path: odimra_kafka_client.key
+              mode: 0444
+            {{- end }}
       restartPolicy: Always
       affinity:
         nodeAffinity:
@@ -53,12 +81,22 @@ spec:
           - mountPath: "/redis-data"
             name: redis-data
             readOnly: false
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: MASTER
           value: "false"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-inmemory-primary-0.redis-ha-inmemory-headless.odim.svc.cluster.local"
         - name: REDIS_ONDISK_DB 
           value: "false"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-inmemory.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT
@@ -78,9 +116,21 @@ spec:
         ports:
         - containerPort: 26379 
 
+        volumeMounts:
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
+
         env:
         - name: SENTINEL
           value: "true"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-inmemory-primary-0.redis-ha-inmemory-headless.odim.svc.cluster.local"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-inmemory.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT

--- a/odim-controller/helmcharts/redis-ha/templates/redis-ha-ondisk-primary-statefulset.yaml
+++ b/odim-controller/helmcharts/redis-ha/templates/redis-ha-ondisk-primary-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.odimra.namespace }}
   labels:
     app: redis-ha-ondisk
+  annotations:
+    secret.reloader.stakater.com/reload: "odimra-secret"
 spec:
   replicas: 1
   serviceName: redis-ha-ondisk-headless
@@ -25,6 +27,33 @@ spec:
         - name: redis-data
           persistentVolumeClaim:
             claimName: redis-ha-ondisk-data-claim
+        - name: odimra-secret
+          secret:
+            secretName: odimra-secret
+            items:
+            - key: rootCAcrt
+              path: rootCA.crt
+              mode: 0444
+            - key: odimra_servercrt
+              path: odimra_server.crt
+              mode: 0444
+            - key: odimra_serverkey
+              path: odimra_server.key
+              mode: 0444
+            - key: odimra_rsapublic
+              path: odimra_rsa.public
+              mode: 0444
+            - key: odimra_rsaprivate
+              path: odimra_rsa.private
+              mode: 0444
+            {{- if eq .Values.odimra.messageBusType "Kafka" }}
+            - key: odimra_kafka_clientcrt
+              path: odimra_kafka_client.crt
+              mode: 0444
+            - key: odimra_kafka_clientkey
+              path: odimra_kafka_client.key
+              mode: 0444
+            {{- end }}
 
       restartPolicy: Always
       affinity:
@@ -56,12 +85,22 @@ spec:
           - mountPath: "/redis-data"
             name: redis-data
             readOnly: false
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: MASTER
           value: "true"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-ondisk-primary-0.redis-ha-ondisk-headless.odim.svc.cluster.local"
         - name: REDIS_ONDISK_DB 
           value: "true"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-ondisk.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT
@@ -78,11 +117,23 @@ spec:
         image: redis:{{ .Values.odimra.redisImageTag }}
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 26379 
+        - containerPort: 26379
+
+        volumeMounts:
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: SENTINEL
           value: "true"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-ondisk-primary-0.redis-ha-ondisk-headless.odim.svc.cluster.local"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-ondisk.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT

--- a/odim-controller/helmcharts/redis-ha/templates/redis-ha-ondisk-secondary-statefulset.yaml
+++ b/odim-controller/helmcharts/redis-ha/templates/redis-ha-ondisk-secondary-statefulset.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Values.odimra.namespace }}
   labels:
     app: redis-ha-ondisk
+  annotations:
+    secret.reloader.stakater.com/reload: "odimra-secret"
 spec:
   replicas: {{ .Values.odimra.redisSecondayReplicaCount }}
   serviceName: redis-ha-ondisk-headless
@@ -25,6 +27,33 @@ spec:
         - name: redis-data
           persistentVolumeClaim:
             claimName: redis-ha-ondisk-data-claim
+        - name: odimra-secret
+          secret:
+            secretName: odimra-secret
+            items:
+            - key: rootCAcrt
+              path: rootCA.crt
+              mode: 0444
+            - key: odimra_servercrt
+              path: odimra_server.crt
+              mode: 0444
+            - key: odimra_serverkey
+              path: odimra_server.key
+              mode: 0444
+            - key: odimra_rsapublic
+              path: odimra_rsa.public
+              mode: 0444
+            - key: odimra_rsaprivate
+              path: odimra_rsa.private
+              mode: 0444
+            {{- if eq .Values.odimra.messageBusType "Kafka" }}
+            - key: odimra_kafka_clientcrt
+              path: odimra_kafka_client.crt
+              mode: 0444
+            - key: odimra_kafka_clientkey
+              path: odimra_kafka_client.key
+              mode: 0444
+            {{- end }}
 
       restartPolicy: Always
       affinity:
@@ -56,12 +85,22 @@ spec:
           - mountPath: "/redis-data"
             name: redis-data
             readOnly: false
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: MASTER
           value: "false"
-        - name: REDIS_ONDISK_DB 
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-ondisk-primary-0.redis-ha-ondisk-headless.odim.svc.cluster.local"
+        - name: REDIS_ONDISK_DB
           value: "true"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-ondisk.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT
@@ -79,11 +118,23 @@ spec:
         imagePullPolicy: IfNotPresent
 
         ports:
-        - containerPort: 26379 
+        - containerPort: 26379
+
+        volumeMounts:
+          - name: odimra-secret
+            mountPath: /etc/odimra_certs
 
         env:
         - name: SENTINEL
           value: "true"
+        - name: MASTER_HOST_NAME
+          value: "redis-ha-ondisk-primary-0.redis-ha-ondisk-headless.odim.svc.cluster.local"
+        - name: TLS_CERT_FILE
+          value: "/etc/odimra_certs/odimra_server.crt"
+        - name: TLS_KEY_FILE
+          value: "/etc/odimra_certs/odimra_server.key"
+        - name: TLS_CA_CERT_FILE
+          value: "/etc/odimra_certs/rootCA.crt"
         - name: REDIS_HA_REDIS_SERVICE_HOST 
           value: "redis-ha-ondisk.{{ .Values.odimra.namespace }}.svc.cluster.local"
         - name: REDIS_HA_REDIS_SERVICE_PORT


### PR DESCRIPTION
**Changes**
- Enabled tls-authentication multinode setup.
- Mounted volume for odimra certificates in Redis-ha pods
- Updated sentinel configuration to resolve master hostname instead of ip when master address is queried 