### PR TITLE
BRUCE-6382-Logging framework is used in all service for logging requirements

### DIFF
--- a/lib-utilities/logs/formatter.go
+++ b/lib-utilities/logs/formatter.go
@@ -23,6 +23,7 @@ import (
 
 var priorityLogFields = []string{
 	"host",
+	"procid",
 }
 
 var syslogPriorityNumerics = map[string]int8{
@@ -59,7 +60,7 @@ type ODIMSysLogFormatter struct{}
 func (f *ODIMSysLogFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	level := entry.Level.String()
 	priorityNumber := findSysLogPriorityNumeric(level)
-	sysLogMsg := fmt.Sprintf("<%d> %s %s", priorityNumber, entry.Time.UTC().Format(time.RFC3339), level)
+	sysLogMsg := fmt.Sprintf("<%d> %s %s ", priorityNumber, entry.Time.UTC().Format(time.RFC3339), level)
 	sysLogMsg = formatPriorityFields(entry, sysLogMsg)
 	for k, v := range logFields {
 		if accountLog, present := formatSyslog(k, v, entry); present {
@@ -80,7 +81,7 @@ func formatPriorityFields(entry *logrus.Entry, msg string) string {
 	for _, v := range priorityLogFields {
 		if val, ok := entry.Data[v]; ok {
 			present = false
-			msg = fmt.Sprintf("%s %v ", msg, val)
+			msg = fmt.Sprintf("%s%v ", msg, val)
 		}
 	}
 	if !present {

--- a/lib-utilities/logs/logger.go
+++ b/lib-utilities/logs/logger.go
@@ -20,7 +20,7 @@ import (
 
 // Logger is used when you import the log package in your service
 // and logging using the package level methods.
-// This can be customized using the functions InitSysLogger or InitJSONLogger
+// This can be customized using the function InitLogger
 var Logger *logrus.Entry
 
 // LogFormat type
@@ -36,6 +36,8 @@ const (
 // Config is used for user configuration
 type Config struct {
 	LogFormat LogFormat
+	Host      string
+	ProcID    string
 }
 
 // InitLogger sets up the Logger and sets up the format and level
@@ -50,6 +52,14 @@ func InitLogger(c *Config) {
 		Logger.Logger.SetFormatter(&logrus.JSONFormatter{})
 	default:
 		Logger.Logger.SetFormatter(&ODIMSysLogFormatter{})
+	}
+
+	if c.Host != "" {
+		Logger = Logger.WithField("host", c.Host)
+	}
+
+	if c.ProcID != "" {
+		Logger = Logger.WithField("procid", c.ProcID)
 	}
 
 	// set the minimum level for logging

--- a/lib-utilities/logs/logger.go
+++ b/lib-utilities/logs/logger.go
@@ -201,44 +201,44 @@ func Panicln(args ...interface{}) {
 	Logger.Panicln(args...)
 }
 
-// TraceWithFileds calls Trace method on package level after appending the fields passed
-func TraceWithFileds(fields map[string]interface{}, args ...interface{}) {
+// TraceWithFields calls Trace method on package level after appending the fields passed
+func TraceWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Trace(args...)
 }
 
-// DebugWithFileds calls Debug method on package level after appending the fields passed
-func DebugWithFileds(fields map[string]interface{}, args ...interface{}) {
+// DebugWithFields calls Debug method on package level after appending the fields passed
+func DebugWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Debug(args...)
 }
 
-// InfoWithFileds calls Info method on package level after appending the fields passed
-func InfoWithFileds(fields map[string]interface{}, args ...interface{}) {
+// InfoWithFields calls Info method on package level after appending the fields passed
+func InfoWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Info(args...)
 }
 
-// PrintWithFileds calls Info method on package level after appending the fields passed
-func PrintWithFileds(fields map[string]interface{}, args ...interface{}) {
+// PrintWithFields calls Info method on package level after appending the fields passed
+func PrintWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Info(args...)
 }
 
-// WarnWithFileds calls Warn method on package level after appending the fields passed
-func WarnWithFileds(fields map[string]interface{}, args ...interface{}) {
+// WarnWithFields calls Warn method on package level after appending the fields passed
+func WarnWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Warn(args...)
 }
 
-// ErrorWithFileds calls Error method on package level after appending the fields passed
-func ErrorWithFileds(fields map[string]interface{}, args ...interface{}) {
+// ErrorWithFields calls Error method on package level after appending the fields passed
+func ErrorWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Error(args...)
 }
 
-// PanicWithFileds calls Panic method on package level after appending the fields passed
-func PanicWithFileds(fields map[string]interface{}, args ...interface{}) {
+// PanicWithFields calls Panic method on package level after appending the fields passed
+func PanicWithFields(fields map[string]interface{}, args ...interface{}) {
 	data := getFields(fields)
 	Logger.WithFields(data).Panic(args...)
 }

--- a/lib-utilities/logs/logger.go
+++ b/lib-utilities/logs/logger.go
@@ -40,9 +40,12 @@ type Config struct {
 	ProcID    string
 }
 
+func init() {
+	Logger = logrus.NewEntry(logrus.New())
+}
+
 // InitLogger sets up the Logger and sets up the format and level
 func InitLogger(c *Config) {
-	Logger = logrus.NewEntry(logrus.New())
 
 	// setting logger format
 	switch c.LogFormat {

--- a/odim-controller/helmcharts/account-session/templates/deployment.yaml
+++ b/odim-controller/helmcharts/account-session/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: account-session:{{ .Values.odimra.accountSessionImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/aggregation/templates/deployment.yaml
+++ b/odim-controller/helmcharts/aggregation/templates/deployment.yaml
@@ -90,6 +90,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: aggregation:{{ .Values.odimra.aggregationImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/api/templates/deployment.yaml
+++ b/odim-controller/helmcharts/api/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: api:{{ .Values.odimra.apiImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/events/templates/deployment.yaml
+++ b/odim-controller/helmcharts/events/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: events:{{ .Values.odimra.eventImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/fabrics/templates/deployment.yaml
+++ b/odim-controller/helmcharts/fabrics/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: fabrics:{{ .Values.odimra.fabricsImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/licenses/templates/deployment.yaml
+++ b/odim-controller/helmcharts/licenses/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: licenses:{{ .Values.odimra.licensesImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/managers/templates/deployment.yaml
+++ b/odim-controller/helmcharts/managers/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: managers:{{ .Values.odimra.managersImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/systems/templates/deployment.yaml
+++ b/odim-controller/helmcharts/systems/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: systems:{{ .Values.odimra.systemsImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/task/templates/deployment.yaml
+++ b/odim-controller/helmcharts/task/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: task:{{ .Values.odimra.taskImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/telemetry/templates/deployment.yaml
+++ b/odim-controller/helmcharts/telemetry/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: telemetry:{{ .Values.odimra.telemetryImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/odim-controller/helmcharts/update/templates/deployment.yaml
+++ b/odim-controller/helmcharts/update/templates/deployment.yaml
@@ -87,6 +87,14 @@ spec:
               value: {{ .Values.odimra.haDeploymentEnabled | quote }}
             - name: ODIM_NAMESPACE
               value: {{ .Values.odimra.namespace | quote }}
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           image: update:{{ .Values.odimra.updateImageTag }}
           imagePullPolicy: IfNotPresent
           ports:

--- a/svc-account-session/account/create.go
+++ b/svc-account-session/account/create.go
@@ -22,11 +22,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"golang.org/x/crypto/sha3"
 	"net/http"
 	"regexp"
 	"strings"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
+	"golang.org/x/crypto/sha3"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-account-session/account/delete.go
+++ b/svc-account-session/account/delete.go
@@ -19,8 +19,9 @@ package account
 // IMPORT Section
 // ---------------------------------------------------------------------------------------
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"

--- a/svc-account-session/account/getaccounts.go
+++ b/svc-account-session/account/getaccounts.go
@@ -19,15 +19,16 @@ package account
 // IMPORT Section
 // ---------------------------------------------------------------------------------------
 import (
+	"net/http"
+
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asmodel"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asresponse"
 	"github.com/ODIM-Project/ODIM/svc-account-session/auth"
-	log "github.com/sirupsen/logrus"
-	"net/http"
 )
 
 // GetAllAccounts defines the admin functionality of listing of all accounts.

--- a/svc-account-session/account/update.go
+++ b/svc-account-session/account/update.go
@@ -21,16 +21,17 @@ package account
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/http"
+
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	accountproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/account"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asmodel"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asresponse"
 	"github.com/ODIM-Project/ODIM/svc-account-session/auth"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/crypto/sha3"
-	"net/http"
 )
 
 // Update defines the updation of the account details. Every account details can be

--- a/svc-account-session/auth/auth.go
+++ b/svc-account-session/auth/auth.go
@@ -16,9 +16,10 @@
 package auth
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"time"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	customLogs "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	authproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/auth"

--- a/svc-account-session/auth/session.go
+++ b/svc-account-session/auth/session.go
@@ -17,9 +17,10 @@ package auth
 
 import (
 	"encoding/base64"
-	log "github.com/sirupsen/logrus"
 	"sync"
 	"time"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"

--- a/svc-account-session/main.go
+++ b/svc-account-session/main.go
@@ -14,8 +14,10 @@
 package main
 
 import (
-	"github.com/sirupsen/logrus"
+	"fmt"
 	"os"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
@@ -27,9 +29,17 @@ import (
 	"github.com/ODIM-Project/ODIM/svc-account-session/rpc"
 )
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
 	// verifying the uid of the user
 	if uid := os.Geteuid(); uid == 0 {
 		log.Fatal("AccountSession Service should not be run as the root user")

--- a/svc-account-session/role/checkprivilege.go
+++ b/svc-account-session/role/checkprivilege.go
@@ -17,8 +17,9 @@ package role
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asmodel"

--- a/svc-account-session/role/create.go
+++ b/svc-account-session/role/create.go
@@ -17,9 +17,10 @@ package role
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"strings"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"

--- a/svc-account-session/role/delete.go
+++ b/svc-account-session/role/delete.go
@@ -25,8 +25,9 @@ import (
 	"github.com/ODIM-Project/ODIM/svc-account-session/auth"
 	"github.com/ODIM-Project/ODIM/svc-account-session/session"
 
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 func doSessionAuthAndUpdate(resp *response.RPC, sessionToken string) (*asmodel.Session, error) {

--- a/svc-account-session/role/getroles.go
+++ b/svc-account-session/role/getroles.go
@@ -16,8 +16,9 @@
 package role
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-account-session/role/update.go
+++ b/svc-account-session/role/update.go
@@ -17,9 +17,10 @@ package role
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"reflect"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	roleproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/role"

--- a/svc-account-session/rpc/account.go
+++ b/svc-account-session/rpc/account.go
@@ -19,8 +19,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-account-session/rpc/role.go
+++ b/svc-account-session/rpc/role.go
@@ -19,8 +19,9 @@ package rpc
 import (
 	"context"
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-account-session/session/create.go
+++ b/svc-account-session/session/create.go
@@ -18,17 +18,18 @@ package session
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
 	customLogs "github.com/ODIM-Project/ODIM/lib-utilities/logs"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	sessionproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/session"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asmodel"
 	"github.com/ODIM-Project/ODIM/svc-account-session/asresponse"
 	"github.com/ODIM-Project/ODIM/svc-account-session/auth"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 
 	"net/http"
 	"time"

--- a/svc-account-session/session/delete.go
+++ b/svc-account-session/session/delete.go
@@ -16,8 +16,9 @@
 package session
 
 import (
-	log "github.com/sirupsen/logrus"
 	"net/http"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	sessionproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/session"

--- a/svc-account-session/session/getsession.go
+++ b/svc-account-session/session/getsession.go
@@ -19,7 +19,7 @@ import (
 	"net/http"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-aggregation/agcommon/common.go
+++ b/svc-aggregation/agcommon/common.go
@@ -27,9 +27,9 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agmodel"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 // DBInterface hold interface for db functions

--- a/svc-aggregation/agmessagebus/publish.go
+++ b/svc-aggregation/agmessagebus/publish.go
@@ -22,8 +22,8 @@ import (
 	dc "github.com/ODIM-Project/ODIM/lib-messagebus/datacommunicator"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 )
 
 //Publish will takes the system id,Event type and publishes the data to message bus

--- a/svc-aggregation/agmodel/system.go
+++ b/svc-aggregation/agmodel/system.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 const (

--- a/svc-aggregation/main.go
+++ b/svc-aggregation/main.go
@@ -14,14 +14,14 @@
 package main
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/sirupsen/logrus"
 
 	dc "github.com/ODIM-Project/ODIM/lib-messagebus/datacommunicator"
 	"github.com/ODIM-Project/ODIM/lib-rest-client/pmbhandle"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agcommon"
@@ -38,9 +38,17 @@ type Schema struct {
 	QueryKeys     []string `json:"queryKeys"`
 }
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
 	// verifying the uid of the user
 	if uid := os.Geteuid(); uid == 0 {
 		log.Fatal("Aggregation Service should not be run as the root user")

--- a/svc-aggregation/rpc/aggregator.go
+++ b/svc-aggregation/rpc/aggregator.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-aggregation/system/addaggregationsource.go
+++ b/svc-aggregation/system/addaggregationsource.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"

--- a/svc-aggregation/system/addcompute.go
+++ b/svc-aggregation/system/addcompute.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-aggregation/system/addplugin.go
+++ b/svc-aggregation/system/addplugin.go
@@ -17,17 +17,18 @@ package system
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/ODIM-Project/ODIM/lib-dmtf/model"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agcommon"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agmodel"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agresponse"
-	log "github.com/sirupsen/logrus"
-	"net/http"
-	"strings"
 )
 
 func (e *ExternalInterface) addPluginData(req AddResourceRequest, taskID, targetURI string, pluginContactRequest getResourceRequest, queueList []string, cmVariants connectionMethodVariants) (response.RPC, string, []byte) {

--- a/svc-aggregation/system/aggregate.go
+++ b/svc-aggregation/system/aggregate.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-aggregation/system/bootorder.go
+++ b/svc-aggregation/system/bootorder.go
@@ -18,11 +18,12 @@ package system
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"net/http"
 	"runtime"
 	"strings"
 	"sync"
+
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"

--- a/svc-aggregation/system/common.go
+++ b/svc-aggregation/system/common.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	dmtf "github.com/ODIM-Project/ODIM/lib-dmtf/model"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"

--- a/svc-aggregation/system/connectionmethods.go
+++ b/svc-aggregation/system/connectionmethods.go
@@ -15,16 +15,17 @@
 package system
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agmodel"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agresponse"
-	log "github.com/sirupsen/logrus"
-	"net/http"
-	"strings"
 )
 
 // GetAllConnectionMethods is the handler for getting the connection methods collection

--- a/svc-aggregation/system/deleteaggregationsource.go
+++ b/svc-aggregation/system/deleteaggregationsource.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	dmtf "github.com/ODIM-Project/ODIM/lib-dmtf/model"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"

--- a/svc-aggregation/system/get_resource.go
+++ b/svc-aggregation/system/get_resource.go
@@ -15,7 +15,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-aggregation/system/pluginHealthCheck.go
+++ b/svc-aggregation/system/pluginHealthCheck.go
@@ -24,11 +24,11 @@ import (
 	"time"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agcommon"
 	"github.com/ODIM-Project/ODIM/svc-aggregation/agmodel"
-	log "github.com/sirupsen/logrus"
 )
 
 var (

--- a/svc-aggregation/system/rediscoverinventory.go
+++ b/svc-aggregation/system/rediscoverinventory.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-aggregation/system/reset.go
+++ b/svc-aggregation/system/reset.go
@@ -23,7 +23,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"

--- a/svc-aggregation/system/update.go
+++ b/svc-aggregation/system/update.go
@@ -21,7 +21,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"

--- a/svc-api/handle/account.go
+++ b/svc-api/handle/account.go
@@ -20,10 +20,10 @@ import (
 	"net/http"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	accountproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/account"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	iris "github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 )
 
 // AccountRPCs defines all the RPC methods in account service

--- a/svc-api/handle/aggregator.go
+++ b/svc-api/handle/aggregator.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"

--- a/svc-api/handle/chassis.go
+++ b/svc-api/handle/chassis.go
@@ -21,10 +21,10 @@ import (
 	"net/http"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	chassisproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/chassis"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 )
 
 // ChassisRPCs defines all the RPC methods in system service

--- a/svc-api/handle/compositionservice.go
+++ b/svc-api/handle/compositionservice.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 

--- a/svc-api/handle/events.go
+++ b/svc-api/handle/events.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	eventsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/events"

--- a/svc-api/handle/fabrics.go
+++ b/svc-api/handle/fabrics.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"

--- a/svc-api/handle/handlers.go
+++ b/svc-api/handle/handlers.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-api/handle/licenses.go
+++ b/svc-api/handle/licenses.go
@@ -20,10 +20,10 @@ import (
 	"net/http"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	licenseproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/licenses"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	iris "github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 )
 
 // LicenseRPCs defines all the RPC methods in license service

--- a/svc-api/handle/managers.go
+++ b/svc-api/handle/managers.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	managersproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/managers"

--- a/svc-api/handle/role.go
+++ b/svc-api/handle/role.go
@@ -20,10 +20,10 @@ import (
 	"net/http"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	roleproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/role"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	iris "github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 )
 
 // RoleRPCs defines all the RPC methods in role

--- a/svc-api/handle/sessions.go
+++ b/svc-api/handle/sessions.go
@@ -20,7 +20,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	sessionproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/session"

--- a/svc-api/handle/systems.go
+++ b/svc-api/handle/systems.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	systemsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/systems"

--- a/svc-api/handle/task.go
+++ b/svc-api/handle/task.go
@@ -18,7 +18,7 @@ package handle
 import (
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	taskproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/task"

--- a/svc-api/handle/telemetry.go
+++ b/svc-api/handle/telemetry.go
@@ -18,7 +18,7 @@ package handle
 import (
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	telemetryproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/telemetry"

--- a/svc-api/handle/update.go
+++ b/svc-api/handle/update.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"reflect"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	updateproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/update"

--- a/svc-api/main.go
+++ b/svc-api/main.go
@@ -16,14 +16,14 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	sessionproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/session"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
@@ -32,9 +32,18 @@ import (
 	iris "github.com/kataras/iris/v12"
 )
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
+
 	// verifying the uid of the user
 	if uid := os.Geteuid(); uid == 0 {
 		log.Fatal("Api Service should not be run as the root user")

--- a/svc-api/middleware/middleware.go
+++ b/svc-api/middleware/middleware.go
@@ -16,9 +16,9 @@
 package middleware
 
 import (
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	"github.com/ODIM-Project/ODIM/svc-api/rpc"
 	iris "github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 )
 
 //SessionDelMiddleware is used to delete session created for basic auth

--- a/svc-api/models/registries.go
+++ b/svc-api/models/registries.go
@@ -17,9 +17,10 @@ package models
 
 import (
 	"encoding/json"
+
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 //GetRegistryFile fetches a resource from database using table and key

--- a/svc-api/ratelimiter/ratelimiter.go
+++ b/svc-api/ratelimiter/ratelimiter.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	iris "github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-api/router/router.go
+++ b/svc-api/router/router.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	customLogs "github.com/ODIM-Project/ODIM/lib-utilities/logs"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	srv "github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-api/handle"
@@ -34,7 +35,6 @@ import (
 	"github.com/ODIM-Project/ODIM/svc-api/ratelimiter"
 	"github.com/ODIM-Project/ODIM/svc-api/rpc"
 	"github.com/kataras/iris/v12"
-	log "github.com/sirupsen/logrus"
 )
 
 //Router method to register API handlers.

--- a/svc-events/consumer/consumer.go
+++ b/svc-events/consumer/consumer.go
@@ -24,7 +24,7 @@ import (
 	dc "github.com/ODIM-Project/ODIM/lib-messagebus/datacommunicator"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 var (

--- a/svc-events/evcommon/common.go
+++ b/svc-events/evcommon/common.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-rest-client/pmbhandle"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"

--- a/svc-events/evcommon/common_test.go
+++ b/svc-events/evcommon/common_test.go
@@ -25,7 +25,7 @@ import (
 	"reflect"
 	"testing"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-events/events/common.go
+++ b/svc-events/events/common.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	taskproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/task"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	errResponse "github.com/ODIM-Project/ODIM/lib-utilities/response"
@@ -26,7 +27,6 @@ import (
 	"github.com/ODIM-Project/ODIM/svc-events/evcommon"
 	"github.com/ODIM-Project/ODIM/svc-events/evmodel"
 	"github.com/ODIM-Project/ODIM/svc-events/evresponse"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/go-playground/validator.v9"
 )
 

--- a/svc-events/events/deletesubscription.go
+++ b/svc-events/events/deletesubscription.go
@@ -31,7 +31,7 @@ import (
 
 	aggregatorproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/aggregator"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-events/events/evtsubscription.go
+++ b/svc-events/events/evtsubscription.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-events/events/publishevttosubscriber.go
+++ b/svc-events/events/publishevttosubscriber.go
@@ -31,7 +31,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-events/events/submittestevent.go
+++ b/svc-events/events/submittestevent.go
@@ -27,8 +27,8 @@ import (
 	"net/http"
 	"time"
 
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	uuid "github.com/satori/go.uuid"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	eventsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/events"

--- a/svc-events/evmodel/events.go
+++ b/svc-events/evmodel/events.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"

--- a/svc-events/main.go
+++ b/svc-events/main.go
@@ -14,22 +14,31 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	dc "github.com/ODIM-Project/ODIM/lib-messagebus/datacommunicator"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	eventsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/events"
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-events/consumer"
 	"github.com/ODIM-Project/ODIM/svc-events/evcommon"
 	"github.com/ODIM-Project/ODIM/svc-events/rpc"
-	"github.com/sirupsen/logrus"
 )
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
 	// verifying the uid of the user
 	if uid := os.Geteuid(); uid == 0 {
 		log.Fatal("Event Service should not be run as the root user")

--- a/svc-events/rpc/events.go
+++ b/svc-events/rpc/events.go
@@ -22,7 +22,7 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-rest-client/pmbhandle"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"

--- a/svc-fabrics/fabrics/addfabric.go
+++ b/svc-fabrics/fabrics/addfabric.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-fabrics/fabmodel"
-	log "github.com/sirupsen/logrus"
 )
 
 //AddFabric holds the logic for Adding fabric

--- a/svc-fabrics/fabrics/common.go
+++ b/svc-fabrics/fabrics/common.go
@@ -18,15 +18,16 @@ package fabrics
 import (
 	"encoding/json"
 	"fmt"
-	dmtf "github.com/ODIM-Project/ODIM/lib-dmtf/model"
-	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"
-	"github.com/ODIM-Project/ODIM/svc-fabrics/fabresponse"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+
+	dmtf "github.com/ODIM-Project/ODIM/lib-dmtf/model"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
+	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"
+	"github.com/ODIM-Project/ODIM/svc-fabrics/fabresponse"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-fabrics/fabrics/removefabric.go
+++ b/svc-fabrics/fabrics/removefabric.go
@@ -20,10 +20,10 @@ import (
 	"strings"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-fabrics/fabmodel"
-	log "github.com/sirupsen/logrus"
 )
 
 // RemoveFabric holds the logic for deleting specfic fabric resource

--- a/svc-fabrics/main.go
+++ b/svc-fabrics/main.go
@@ -14,22 +14,30 @@
 package main
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/sirupsen/logrus"
 
 	"github.com/ODIM-Project/ODIM/lib-rest-client/pmbhandle"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-fabrics/fabrics"
 	"github.com/ODIM-Project/ODIM/svc-fabrics/rpc"
 )
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
 
 	// verifying the uid of the user
 	if uid := os.Geteuid(); uid == 0 {

--- a/svc-fabrics/rpc/fabrics.go
+++ b/svc-fabrics/rpc/fabrics.go
@@ -21,7 +21,7 @@ import (
 
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	fabricsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/fabrics"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"

--- a/svc-licenses/lcommon/common.go
+++ b/svc-licenses/lcommon/common.go
@@ -29,7 +29,7 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-licenses/model"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 //GetAllKeysFromTable fetches all keys in a given table

--- a/svc-licenses/licenses/licenses.go
+++ b/svc-licenses/licenses/licenses.go
@@ -28,7 +28,7 @@ import (
 	lcommon "github.com/ODIM-Project/ODIM/svc-licenses/lcommon"
 	"github.com/ODIM-Project/ODIM/svc-licenses/model"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 var (
@@ -141,7 +141,7 @@ func (e *ExternalInterface) InstallLicenseService(req *licenseproto.InstallLicen
 	} else if len(installreq.Links.Link) == 0 {
 		errMsg := "Invalid request, mandatory field AuthorizedDevices links is missing"
 		log.Error(errMsg)
-	return common.GeneralError(http.StatusBadRequest, response.PropertyMissing, errMsg, []interface{}{"LicenseString"}, nil)
+		return common.GeneralError(http.StatusBadRequest, response.PropertyMissing, errMsg, []interface{}{"LicenseString"}, nil)
 
 	}
 	var serverURI string

--- a/svc-licenses/main.go
+++ b/svc-licenses/main.go
@@ -15,20 +15,29 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	licenseproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/licenses"
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-licenses/rpc"
-
-	"github.com/sirupsen/logrus"
 )
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
+
 	if uid := os.Geteuid(); uid == 0 {
 		log.Error("Licenses Service should not be run as the root user")
 	}

--- a/svc-licenses/rpc/common.go
+++ b/svc-licenses/rpc/common.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-licenses/licenses"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 )
 
 // Licenses struct helps to register service

--- a/svc-managers/main.go
+++ b/svc-managers/main.go
@@ -17,13 +17,12 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/sirupsen/logrus"
-
 	"fmt"
 
 	dmtf "github.com/ODIM-Project/ODIM/lib-dmtf/model"
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	managersproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/managers"
 	"github.com/ODIM-Project/ODIM/lib-utilities/services"
 	"github.com/ODIM-Project/ODIM/svc-managers/managers"
@@ -32,9 +31,17 @@ import (
 	"github.com/ODIM-Project/ODIM/svc-managers/rpc"
 )
 
-var log = logrus.New()
-
 func main() {
+	// setting up the logging framework
+	hostname := os.Getenv("HOST_NAME")
+	podname := os.Getenv("POD_NAME")
+	pid := os.Getpid()
+	c := &log.Config{
+		LogFormat: log.SysLogFormat,
+		Host:      hostname,
+		ProcID:    podname + fmt.Sprintf("_%d", pid),
+	}
+	log.InitLogger(c)
 
 	// verifying the uid of the user
 	if uid := os.Geteuid(); uid == 0 {

--- a/svc-managers/managers/managers.go
+++ b/svc-managers/managers/managers.go
@@ -27,12 +27,12 @@ import (
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
 	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 	managersproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/managers"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-managers/mgrcommon"
 	"github.com/ODIM-Project/ODIM/svc-managers/mgrmodel"
 	"github.com/ODIM-Project/ODIM/svc-managers/mgrresponse"
-	log "github.com/sirupsen/logrus"
 	"gopkg.in/go-playground/validator.v9"
 )
 

--- a/svc-managers/mgrcommon/common.go
+++ b/svc-managers/mgrcommon/common.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"

--- a/svc-managers/rpc/manager.go
+++ b/svc-managers/rpc/manager.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
+	log "github.com/ODIM-Project/ODIM/lib-utilities/logs"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	managersproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/managers"


### PR DESCRIPTION

- **Changes**
- Host and processID can be configured while setting up the logging framework
- Logging framework is used in the services API, account, aggregation, events, fabrics, licenses, managers

