### PR TITLE
Create a base structure for queuing of requests in ODIM and Plugin

### DIFF
--- a/lib-utilities/common/constants.go
+++ b/lib-utilities/common/constants.go
@@ -660,5 +660,9 @@ var URIWithNoAuth = []string{
 
 var SessionURI = "/redfish/v1/SessionService/Sessions"
 
+// TaskEventsTopic: topic name for task events
+// TODO: make configurable
+var TaskEventsTopic = "TASK-EVENTS-TOPIC"
+
 // XForwardedFor holds the IP of plugin instance in response header
 var XForwardedFor = "Xforwarded-for"

--- a/lib-utilities/common/constants.go
+++ b/lib-utilities/common/constants.go
@@ -665,4 +665,4 @@ var SessionURI = "/redfish/v1/SessionService/Sessions"
 var TaskEventsTopic = "TASK-EVENTS-TOPIC"
 
 // XForwardedFor holds the IP of plugin instance in response header
-var XForwardedFor = "Xforwarded-for"
+var XForwardedFor = "X-Forwarded-For"

--- a/lib-utilities/common/constants.go
+++ b/lib-utilities/common/constants.go
@@ -599,6 +599,8 @@ type TaskEvent struct {
 	TaskState       string    `json:"TaskState"`
 	TaskStatus      string    `json:"TaskStatus"`
 	PercentComplete int32     `json:"PercentComplete"`
+	StatusCode      int32     `json:"StatusCode"`
+	ResponseBody    []byte    `json:"ResponseBody"`
 	EndTime         time.Time `json:"EndTime"`
 }
 

--- a/lib-utilities/common/constants.go
+++ b/lib-utilities/common/constants.go
@@ -662,9 +662,5 @@ var URIWithNoAuth = []string{
 
 var SessionURI = "/redfish/v1/SessionService/Sessions"
 
-// TaskEventsTopic: topic name for task events
-// TODO: make configurable
-var TaskEventsTopic = "TASK-EVENTS-TOPIC"
-
 // XForwardedFor holds the IP of plugin instance in response header
 var XForwardedFor = "X-Forwarded-For"

--- a/lib-utilities/common/constants.go
+++ b/lib-utilities/common/constants.go
@@ -15,6 +15,8 @@
 // Package common ...
 package common
 
+import "time"
+
 // EventConst constant
 type EventConst int
 
@@ -591,6 +593,25 @@ type Events struct {
 	EventType string `json:"eventType"`
 }
 
+// TaskEvent contains the task progress data sent form plugin to PMB
+type TaskEvent struct {
+	TaskID          string    `json:"TaskID"`
+	TaskState       string    `json:"TaskState"`
+	TaskStatus      string    `json:"TaskStatus"`
+	PercentComplete int32     `json:"PercentComplete"`
+	EndTime         time.Time `json:"EndTime"`
+}
+
+// PluginTask contains the IP of the plugin instance that returns plugin taskmon,
+// task id created in odim, and taskmon url sent by plugin
+// it is used to map the odim task to plugin task and to know the IP
+// of plugin instance that handle the task
+type PluginTask struct {
+	IP               string `json:"IP"`
+	OdimTaskID       string `json:"OdimTaskID"`
+	PluginTaskMonURL string `json:"PluginTaskMonURL"`
+}
+
 // MessageData contains information of Events and message details including arguments
 // it will be used to pass to gob encoding/decoding which will register the type.
 // it will be send as byte stream on the wire to/from kafka
@@ -638,3 +659,6 @@ var URIWithNoAuth = []string{
 }
 
 var SessionURI = "/redfish/v1/SessionService/Sessions"
+
+// XForwardedFor holds the IP of plugin instance in response header
+var XForwardedFor = "Xforwarded-for"

--- a/lib-utilities/config/config.go
+++ b/lib-utilities/config/config.go
@@ -99,6 +99,7 @@ type MessageBusConf struct {
 	MessageBusConfigFilePath string `json:"MessageBusConfigFilePath"`
 	MessageBusType           string `json:"MessageBusType"`
 	OdimControlMessageQueue  string `json:"OdimControlMessageQueue"`
+	OdimTaskEventsQueue      string `json:"OdimTaskEventsQueue"`
 }
 
 // KeyCertConf is for holding all security oriented configuration
@@ -387,6 +388,10 @@ func checkMessageBusConf(wl *WarningList) error {
 		if len(Data.MessageBusConf.OdimControlMessageQueue) <= 0 {
 			wl.add("No value set for MessageBusQueue, setting default value")
 			Data.MessageBusConf.OdimControlMessageQueue = "ODIM-CONTROL-MESSAGES"
+		}
+		if Data.MessageBusConf.OdimTaskEventsQueue == "" {
+			wl.add("No value set for OdimTaskEventsQueue, setting default value")
+			Data.MessageBusConf.OdimTaskEventsQueue = "TASK-EVENTS-TOPIC"
 		}
 	}
 	if !AllowedMessageBusTypes[Data.MessageBusConf.MessageBusType] {

--- a/odim-controller/helmcharts/odimra-config/templates/configmaps.yaml
+++ b/odim-controller/helmcharts/odimra-config/templates/configmaps.yaml
@@ -27,7 +27,8 @@ data:
        "MessageBusConf": {
          "MessageBusConfigFilePath": "/etc/odimra_config/platformconfig.toml",
          "MessageBusType": {{ .Values.odimra.messageBusType | quote }},
-         "OdimControlMessageQueue": "ODIM-CONTROL-MESSAGES"
+         "OdimControlMessageQueue": "ODIM-CONTROL-MESSAGES",
+         "OdimTaskEventsQueue": "TASK-EVENTS-TOPIC"
       },
     	"DBConf": {
                 "Protocol": "tcp",

--- a/svc-systems/scommon/common.go
+++ b/svc-systems/scommon/common.go
@@ -106,7 +106,7 @@ func GetResourceInfoFromDevice(ctx context.Context, req ResourceInfoRequest, sav
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, _, err := ContactPlugin(ctx, contactRequest, "error while getting the details "+contactRequest.OID+": ")
+		_, token, _, _, err := ContactPlugin(ctx, contactRequest, "error while getting the details "+contactRequest.OID+": ")
 		if err != nil {
 
 			return "", err
@@ -134,7 +134,7 @@ func GetResourceInfoFromDevice(ctx context.Context, req ResourceInfoRequest, sav
 	//replace the uuid:system id with the system to the @odata.id from request url
 	contactRequest.OID = strings.Replace(req.URL, req.UUID+"."+req.SystemID, req.SystemID, -1)
 	contactRequest.HTTPMethodType = http.MethodGet
-	body, _, _, err := ContactPlugin(ctx, contactRequest, "error while getting the details "+contactRequest.OID+": ")
+	body, _, _, _, err := ContactPlugin(ctx, contactRequest, "error while getting the details "+contactRequest.OID+": ")
 	if err != nil {
 		return "", err
 	}
@@ -209,7 +209,7 @@ func getResourceName(oDataID string, memberFlag bool) string {
 }
 
 // ContactPlugin is commons which handles the request and response of Contact Plugin usage
-func ContactPlugin(ctx context.Context, req PluginContactRequest, errorMessage string) ([]byte, string, ResponseStatus, error) {
+func ContactPlugin(ctx context.Context, req PluginContactRequest, errorMessage string) ([]byte, string, string, ResponseStatus, error) {
 	l.LogWithFields(ctx).Debugf("incoming ContactPlugin request with token: %s, OID: %s", req.Token, req.OID)
 	var resp ResponseStatus
 	var response *http.Response
@@ -224,7 +224,7 @@ func ContactPlugin(ctx context.Context, req PluginContactRequest, errorMessage s
 			resp.StatusCode = http.StatusInternalServerError
 			resp.StatusMessage = errors.InternalError
 			l.LogWithFields(ctx).Error(errorMessage)
-			return nil, "", resp, fmt.Errorf(errorMessage)
+			return nil, "", "", resp, fmt.Errorf(errorMessage)
 		}
 	}
 	defer response.Body.Close()
@@ -234,14 +234,14 @@ func ContactPlugin(ctx context.Context, req PluginContactRequest, errorMessage s
 		resp.StatusCode = http.StatusInternalServerError
 		resp.StatusMessage = errors.InternalError
 		l.LogWithFields(ctx).Error(errorMessage)
-		return nil, "", resp, fmt.Errorf(errorMessage)
+		return nil, "", "", resp, fmt.Errorf(errorMessage)
 	}
 	l.LogWithFields(ctx).Info("response.StatusCode: " + fmt.Sprintf("%d", response.StatusCode))
 	resp.StatusCode = int32(response.StatusCode)
 	if response.StatusCode != http.StatusCreated && response.StatusCode != http.StatusOK && response.StatusCode != http.StatusAccepted {
 		resp.StatusCode = int32(response.StatusCode)
 		l.LogWithFields(ctx).Println(errorMessage)
-		return body, "", resp, fmt.Errorf(errorMessage)
+		return body, "", "", resp, fmt.Errorf(errorMessage)
 	}
 
 	data := string(body)
@@ -249,10 +249,12 @@ func ContactPlugin(ctx context.Context, req PluginContactRequest, errorMessage s
 	for key, value := range config.Data.URLTranslation.NorthBoundURL {
 		data = strings.Replace(data, key, value, -1)
 	}
+
 	if response.StatusCode == http.StatusAccepted {
-		return []byte(data), response.Header.Get("Location"), resp, nil
+		return []byte(data), response.Header.Get("Location"),
+			response.Header.Get(common.XForwardedFor), resp, nil
 	}
-	return []byte(data), response.Header.Get("X-Auth-Token"), resp, nil
+	return []byte(data), response.Header.Get("X-Auth-Token"), "", resp, nil
 }
 
 func checkRetrievalInfo(oid string) bool {
@@ -301,6 +303,26 @@ func callPlugin(ctx context.Context, req PluginContactRequest) (*http.Response, 
 		return req.ContactClient(ctx, reqURL, req.HTTPMethodType, "", oid, req.DeviceInfo, req.BasicAuth)
 	}
 	return req.ContactClient(ctx, reqURL, req.HTTPMethodType, req.Token, oid, req.DeviceInfo, nil)
+}
+
+// SavePluginTaskInfo saves the ip of plugin instance that handle the task,
+// task id of task which created in odim, and the taskmon URL returned
+// from plugin in DB
+func SavePluginTaskInfo(ctx context.Context, pluginIP, odimTaskID,
+	pluginTaskMonURL string) {
+
+	pluginTaskID := strings.TrimPrefix(pluginTaskMonURL, "/taskmon/")
+	pluginTaskInfo := common.PluginTask{
+		IP:               pluginIP,
+		OdimTaskID:       odimTaskID,
+		PluginTaskMonURL: pluginTaskMonURL,
+	}
+
+	err := smodel.CreatePluginTask(ctx, pluginTaskID, pluginTaskInfo)
+	if err != nil {
+		l.LogWithFields(ctx).Error("Error while saving plugin task info in DB",
+			err)
+	}
 }
 
 // TrackConfigFileChanges monitors the odim config changes using fsnotfiy

--- a/svc-systems/scommon/common_test.go
+++ b/svc-systems/scommon/common_test.go
@@ -17,7 +17,6 @@ package scommon
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -210,7 +209,7 @@ func TestGetResourceInfoFromDevice(t *testing.T) {
 		return ioutil.ReadAll(r)
 	}
 	JSONUnmarshalFunc = func(data []byte, v interface{}) error {
-		return errors.New("")
+		return fmt.Errorf("")
 	}
 	_, err = GetResourceInfoFromDevice(ctx, req, true)
 	assert.NotNil(t, err, "There should be error")
@@ -501,6 +500,37 @@ func Test_keyFormation(t *testing.T) {
 			if got := keyFormation(tt.args.oid, tt.args.systemID, tt.args.DeviceUUID); got != tt.want {
 				t.Errorf("keyFormation() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestSavePluginTaskInfo(t *testing.T) {
+	config.SetUpMockConfig(t)
+	odimTaskID := "task3b7a2fc0-40aa-4788-961f-d201ee6ced4d"
+	pluginTaskID := "task3a7a2fc0-40aa-4788-961f-d201ee6ced4c"
+	type args struct {
+		ctx              context.Context
+		pluginIP         string
+		odimTaskID       string
+		pluginTaskMonURL string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "save plugin task info in db",
+			args: args{
+				ctx:              context.TODO(),
+				pluginIP:         "127.0.0.1",
+				odimTaskID:       odimTaskID,
+				pluginTaskMonURL: "/taskmon/" + pluginTaskID,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SavePluginTaskInfo(tt.args.ctx, tt.args.pluginIP, tt.args.odimTaskID, tt.args.pluginTaskMonURL)
 		})
 	}
 }

--- a/svc-systems/scommon/common_test.go
+++ b/svc-systems/scommon/common_test.go
@@ -370,7 +370,7 @@ func TestContactPlugin(t *testing.T) {
 	contactRequest.ContactClient = mockContactClient
 	contactRequest.Plugin = plugin
 	contactRequest.GetPluginStatus = mockPluginStatus
-	_, _, _, err = ContactPlugin(ctx, contactRequest, "")
+	_, _, _, _, err = ContactPlugin(ctx, contactRequest, "")
 	assert.NotNil(t, err, "There should be an error")
 }
 

--- a/svc-systems/smodel/systems.go
+++ b/svc-systems/smodel/systems.go
@@ -389,3 +389,21 @@ func DeleteVolume(ctx context.Context, key string) *errors.Error {
 	}
 	return nil
 }
+
+// CreatePluginTask will insert plugin task info in DB
+func CreatePluginTask(ctx context.Context, key string,
+	value interface{}) *errors.Error {
+
+	table := "PluginTask"
+	connPool, err := GetDBConnectionFunc(common.InMemory)
+	if err != nil {
+		return errors.PackError(err.ErrNo(), "error while trying to connecting"+
+			" to DB: ", err.Error())
+	}
+
+	if err = connPool.Create(table, key, value); err != nil {
+		return errors.PackError(err.ErrNo(), "error while trying to insert"+
+			" plugin task: ", err.Error())
+	}
+	return nil
+}

--- a/svc-systems/smodel/systems_test.go
+++ b/svc-systems/smodel/systems_test.go
@@ -17,6 +17,7 @@
 package smodel
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -641,4 +642,42 @@ func TestGetAllKeysFromTable(t *testing.T) {
 		return common.GetDBConnection(dbFlag)
 	}
 
+}
+
+func TestCreatePluginTask(t *testing.T) {
+	config.SetUpMockConfig(t)
+	odimTaskID := "task3b7a2fc0-40aa-4788-961f-d201ee6ced4d"
+	pluginTaskID := "task3a7a2fc0-40aa-4788-961f-d201ee6ced4c"
+	type args struct {
+		ctx   context.Context
+		key   string
+		value interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "insert plugin task info in DB",
+			args: args{
+				ctx: context.TODO(),
+				key: pluginTaskID,
+				value: common.PluginTask{
+					IP:               "127.0.0.1",
+					OdimTaskID:       odimTaskID,
+					PluginTaskMonURL: pluginTaskID,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := CreatePluginTask(tt.args.ctx, tt.args.key, tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreatePluginTask()  error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
 }

--- a/svc-systems/systems/bootorder.go
+++ b/svc-systems/systems/bootorder.go
@@ -74,7 +74,7 @@ func (p *PluginContact) SetDefaultBootOrder(ctx context.Context, systemID string
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
+		_, token, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
 
 		if err != nil {
 			return common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage, err.Error(), nil, nil)
@@ -94,7 +94,7 @@ func (p *PluginContact) SetDefaultBootOrder(ctx context.Context, systemID string
 	contactRequest.OID = "/ODIM/v1/Systems/" + requestData[1] + "/Actions/ComputerSystem.SetDefaultBootOrder"
 	contactRequest.HTTPMethodType = http.MethodPost
 
-	body, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while setting the default bootorder of  the computer system: ")
+	body, _, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while setting the default bootorder of  the computer system: ")
 	if err != nil {
 		resp.StatusCode = getResponse.StatusCode
 		json.Unmarshal(body, &resp.Body)
@@ -175,7 +175,7 @@ func (p *PluginContact) ChangeBiosSettings(ctx context.Context, req *systemsprot
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
+		_, token, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
 
 		if err != nil {
 			return common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage, err.Error(), nil, nil)
@@ -194,7 +194,7 @@ func (p *PluginContact) ChangeBiosSettings(ctx context.Context, req *systemsprot
 	contactRequest.DeviceInfo = target
 	contactRequest.OID = fmt.Sprintf("/ODIM/v1/Systems/%s/Bios/Settings", requestData[1])
 
-	body, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while changing  bios settings: ")
+	body, _, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while changing  bios settings: ")
 	if err != nil {
 		resp.StatusCode = getResponse.StatusCode
 		json.Unmarshal(body, &resp.Body)
@@ -289,7 +289,7 @@ func (p *PluginContact) ChangeBootOrderSettings(ctx context.Context, req *system
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
+		_, token, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
 
 		if err != nil {
 			return common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage, err.Error(), nil, nil)
@@ -309,7 +309,7 @@ func (p *PluginContact) ChangeBootOrderSettings(ctx context.Context, req *system
 	contactRequest.DeviceInfo = target
 	contactRequest.OID = fmt.Sprintf("/ODIM/v1/Systems/%s", requestData[1])
 
-	body, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while changing boot order settings: ")
+	body, _, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while changing boot order settings: ")
 	if err != nil {
 		resp.StatusCode = getResponse.StatusCode
 		json.Unmarshal(body, &resp.Body)

--- a/svc-systems/systems/bootorder_test.go
+++ b/svc-systems/systems/bootorder_test.go
@@ -228,7 +228,7 @@ func TestPluginContact_SetDefaultBootOrder(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return true
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
@@ -238,13 +238,13 @@ func TestPluginContact_SetDefaultBootOrder(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return false
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
 	resp = pluginContact.SetDefaultBootOrder(ctx, "7a2c6100-67da-5fd6-ab82-6870d29c7279.1")
 	assert.NotNil(t, resp, "Response should have error")
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		return scommon.ContactPlugin(ctx, req, errorMessage)
 	}
 	JSONUnmarshalFunc = func(data []byte, v interface{}) error {
@@ -468,7 +468,7 @@ func TestPluginContact_ChangeBiosSettings(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return true
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
@@ -478,14 +478,14 @@ func TestPluginContact_ChangeBiosSettings(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return false
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
 	res = pluginContact.ChangeBiosSettings(ctx, &req)
 	assert.NotNil(t, res, "Response should have error")
 
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		return scommon.ContactPlugin(ctx, req, errorMessage)
 	}
 
@@ -735,7 +735,7 @@ func TestPluginContact_ChangeBootOrderSettings(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return true
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (d []byte, d1 string, d2 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (d []byte, d1 string, d2 string, d3 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
@@ -744,14 +744,14 @@ func TestPluginContact_ChangeBootOrderSettings(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return false
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (d []byte, d1 string, d2 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (d []byte, d1 string, d2 string, d3 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
 	resp = pluginContact.ChangeBootOrderSettings(ctx, &req)
 	assert.NotNil(t, resp, "Response should have error")
 
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (d []byte, d1 string, d2 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (d []byte, d1 string, d2 string, d3 scommon.ResponseStatus, err error) {
 		return scommon.ContactPlugin(ctx, req, errorMessage)
 	}
 

--- a/svc-systems/systems/common.go
+++ b/svc-systems/systems/common.go
@@ -138,7 +138,7 @@ func (e *PluginContact) monitorPluginTask(ctx context.Context, monitorTaskData *
 		time.Sleep(time.Second * 5)
 		monitorTaskData.pluginRequest.OID = monitorTaskData.location
 		monitorTaskData.pluginRequest.HTTPMethodType = http.MethodGet
-		monitorTaskData.respBody, _, monitorTaskData.getResponse, err = ContactPluginFunc(ctx, monitorTaskData.pluginRequest, "error while reseting the computer system: ")
+		monitorTaskData.respBody, _, _, monitorTaskData.getResponse, err = ContactPluginFunc(ctx, monitorTaskData.pluginRequest, "error while reseting the computer system: ")
 		if err != nil {
 			errMsg := err.Error()
 			l.LogWithFields(ctx).Warn(errMsg)

--- a/svc-systems/systems/reset.go
+++ b/svc-systems/systems/reset.go
@@ -43,75 +43,71 @@ var (
 )
 
 // ComputerSystemReset performs a reset action on the requeseted computer system with the specified ResetType
-func (p *PluginContact) ComputerSystemReset(ctx context.Context, req *systemsproto.ComputerSystemResetRequest, taskID, sessionUserName string) response.RPC {
+func (p *PluginContact) ComputerSystemReset(ctx context.Context,
+	req *systemsproto.ComputerSystemResetRequest, taskID, sessionUserName string) {
 	var targetURI = "/redfish/v1/Systems/" + req.SystemID + "/Actions/ComputerSystem.Reset"
 	var resp response.RPC
 	resp.StatusCode = http.StatusAccepted
-	var percentComplete int32
-	var task = fillTaskData(taskID, targetURI, string(req.RequestBody), resp, common.Running, common.OK, percentComplete, http.MethodPost)
-	err := p.UpdateTask(ctx, task)
-	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI, UpdateTask: p.UpdateTask, TaskRequest: string(req.RequestBody)}
+	taskInfo := &common.TaskUpdateInfo{TaskID: taskID, TargetURI: targetURI,
+		UpdateTask: p.UpdateTask, TaskRequest: string(req.RequestBody)}
 
-	if err != nil {
-		errMsg := "error while starting the task: " + err.Error()
-		l.LogWithFields(ctx).Error(errMsg)
-		return common.GeneralError(http.StatusInternalServerError, response.InternalError, errMsg, nil, taskInfo)
-	}
-	percentComplete = 10
-	task = fillTaskData(taskID, targetURI, string(req.RequestBody), resp, common.Running, common.OK, percentComplete, http.MethodPost)
-	p.UpdateTask(ctx, task)
 	// parsing the ResetComputerSystem
 	var resetCompSys ResetComputerSystem
-	err = JSONUnMarshal(req.RequestBody, &resetCompSys)
+	err := JSONUnMarshal(req.RequestBody, &resetCompSys)
 	if err != nil {
 		errMsg := "error: unable to parse the computer system reset request" + err.Error()
 		l.LogWithFields(ctx).Error(errMsg)
-		return common.GeneralError(http.StatusInternalServerError, response.InternalError, errMsg, nil, taskInfo)
+		common.GeneralError(http.StatusInternalServerError,
+			response.InternalError, errMsg, nil, taskInfo)
 	}
 
 	// Validating the request JSON properties for case sensitive
-	invalidProperties, err := RequestParamsCaseValidatorFunc(req.RequestBody, resetCompSys)
+	invalidProperties, err := RequestParamsCaseValidatorFunc(req.RequestBody,
+		resetCompSys)
 	if err != nil {
 		errMsg := "error while validating request parameters: " + err.Error()
 		l.LogWithFields(ctx).Error(errMsg)
-		return common.GeneralError(http.StatusInternalServerError, response.InternalError, errMsg, nil, taskInfo)
+		common.GeneralError(http.StatusInternalServerError,
+			response.InternalError, errMsg, nil, taskInfo)
 	} else if invalidProperties != "" {
-		errorMessage := "error: one or more properties given in the request body are not valid, ensure properties are listed in uppercamelcase "
+		errorMessage := "error: one or more properties given in the request" +
+			" body are not valid, ensure properties are listed in upper camel case "
 		l.LogWithFields(ctx).Error(errorMessage)
-		resp := common.GeneralError(http.StatusBadRequest, response.PropertyUnknown, errorMessage, []interface{}{invalidProperties}, taskInfo)
-		return resp
+		common.GeneralError(http.StatusBadRequest, response.PropertyUnknown,
+			errorMessage, []interface{}{invalidProperties}, taskInfo)
 	}
 
 	// spliting the uuid and system id
 	requestData := strings.SplitN(req.SystemID, ".", 2)
 	if len(requestData) <= 1 {
 		errorMessage := "error: SystemUUID not found"
-		return common.GeneralError(http.StatusNotFound, response.ResourceNotFound, errorMessage, []interface{}{"System", req.SystemID}, taskInfo)
+		common.GeneralError(http.StatusNotFound, response.ResourceNotFound,
+			errorMessage, []interface{}{"System", req.SystemID}, taskInfo)
 	}
 
 	uuid := requestData[0]
-
 	target, gerr := smodel.GetTarget(uuid)
 	if gerr != nil {
-		return common.GeneralError(http.StatusNotFound, response.ResourceNotFound, gerr.Error(), []interface{}{"ComputerSystem", "/redfish/v1/Systems/" + req.SystemID}, taskInfo)
+		common.GeneralError(http.StatusNotFound, response.ResourceNotFound,
+			gerr.Error(), []interface{}{"ComputerSystem", "/redfish/v1/Systems/" +
+				req.SystemID}, taskInfo)
 	}
 	decryptedPasswordByte, err := p.DevicePassword(target.Password)
 	if err != nil {
 		// Frame the RPC response body and response Header below
 		errorMessage := "error while trying to decrypt device password: " + err.Error()
-		return common.GeneralError(http.StatusInternalServerError, response.InternalError, errorMessage, nil, taskInfo)
+		common.GeneralError(http.StatusInternalServerError, response.InternalError,
+			errorMessage, nil, taskInfo)
 	}
-	target.Password = decryptedPasswordByte
-	percentComplete = 30
-	task = fillTaskData(taskID, targetURI, string(req.RequestBody), resp, common.Running, common.OK, percentComplete, http.MethodPost)
-	p.UpdateTask(ctx, task)
 
-	// Get the Plugin info
+	target.Password = decryptedPasswordByte
 	plugin, gerr := smodel.GetPluginData(target.PluginID)
 	if gerr != nil {
 		errorMessage := "error while trying to get plugin details"
-		return common.GeneralError(http.StatusInternalServerError, response.InternalError, errorMessage, nil, nil)
+		common.GeneralError(http.StatusInternalServerError,
+			response.InternalError, errorMessage, nil, nil)
 	}
+
 	var contactRequest scommon.PluginContactRequest
 	contactRequest.ContactClient = p.ContactClient
 	contactRequest.Plugin = plugin
@@ -124,10 +120,12 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context, req *systemspro
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating session with the plugin: ")
+		_, token, _, getResponse, err := ContactPluginFunc(ctx, contactRequest,
+			"error while creating session with the plugin: ")
 
 		if err != nil {
-			return common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage, err.Error(), nil, nil)
+			common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage,
+				err.Error(), nil, nil)
 		}
 		contactRequest.Token = token
 	} else {
@@ -137,44 +135,34 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context, req *systemspro
 		}
 
 	}
+
 	postRequest := make(map[string]interface{})
 	postRequest["ResetType"] = resetCompSys.ResetType
 	postBody, _ := json.Marshal(postRequest)
 	target.PostBody = postBody
 	contactRequest.HTTPMethodType = http.MethodPost
 	contactRequest.DeviceInfo = target
-	contactRequest.OID = "/ODIM/v1/Systems/" + requestData[1] + "/Actions/ComputerSystem.Reset"
-	body, location, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while reseting the computer system: ")
+	contactRequest.OID = "/ODIM/v1/Systems/" + requestData[1] +
+		"/Actions/ComputerSystem.Reset"
+	body, location, pluginIP, getResponse, err := ContactPluginFunc(ctx,
+		contactRequest, "error while reseting the computer system: ")
 	if err != nil {
 		resp.StatusCode = getResponse.StatusCode
 		json.Unmarshal(body, &resp.Body)
-		task = fillTaskData(taskID, targetURI, string(req.RequestBody), resp, common.Exception, common.Critical, 100, http.MethodPost)
+		task := fillTaskData(taskID, targetURI, string(req.RequestBody), resp,
+			common.Exception, common.Critical, 100, http.MethodPost)
 		err = p.UpdateTask(ctx, task)
 		if err != nil {
 			errMsg := "error while starting the task: " + err.Error()
 			l.LogWithFields(ctx).Error(errMsg)
-			return common.GeneralError(http.StatusInternalServerError, response.InternalError, errMsg, nil, taskInfo)
+			common.GeneralError(http.StatusInternalServerError, response.InternalError,
+				errMsg, nil, taskInfo)
 		}
-
-		return resp
 	}
+
 	if getResponse.StatusCode == http.StatusAccepted {
-
-		body, err = p.monitorPluginTask(ctx, &monitorTaskRequest{
-			taskID:        taskID,
-			serverURI:     targetURI,
-			requestBody:   string(postBody),
-			respBody:      body,
-			getResponse:   getResponse,
-			taskInfo:      taskInfo,
-			location:      location,
-			pluginRequest: contactRequest,
-			resp:          resp,
-		})
-
-		if err != nil {
-			return resp
-		}
+		scommon.SavePluginTaskInfo(ctx, pluginIP, taskID, location)
+		return
 	}
 
 	resp.StatusCode = http.StatusOK
@@ -182,11 +170,12 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context, req *systemspro
 
 	err = JSONUnmarshalFunc(body, &resp.Body)
 	if err != nil {
-		return common.GeneralError(http.StatusInternalServerError, response.InternalError, err.Error(), nil, taskInfo)
+		common.GeneralError(http.StatusInternalServerError,
+			response.InternalError, err.Error(), nil, taskInfo)
 	}
-	smodel.AddSystemResetInfo(ctx, "/redfish/v1/Systems/"+req.SystemID, resetCompSys.ResetType)
-	task = fillTaskData(taskID, targetURI, string(req.RequestBody), resp, common.Completed, common.OK, 100, http.MethodPost)
+	smodel.AddSystemResetInfo(ctx, "/redfish/v1/Systems/"+req.SystemID,
+		resetCompSys.ResetType)
+	task := fillTaskData(taskID, targetURI, string(req.RequestBody), resp,
+		common.Completed, common.OK, 100, http.MethodPost)
 	p.UpdateTask(ctx, task)
-
-	return resp
 }

--- a/svc-systems/systems/reset.go
+++ b/svc-systems/systems/reset.go
@@ -59,6 +59,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 		l.LogWithFields(ctx).Error(errMsg)
 		common.GeneralError(http.StatusInternalServerError,
 			response.InternalError, errMsg, nil, taskInfo)
+		return
 	}
 
 	// Validating the request JSON properties for case sensitive
@@ -69,12 +70,14 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 		l.LogWithFields(ctx).Error(errMsg)
 		common.GeneralError(http.StatusInternalServerError,
 			response.InternalError, errMsg, nil, taskInfo)
+		return
 	} else if invalidProperties != "" {
 		errorMessage := "error: one or more properties given in the request" +
 			" body are not valid, ensure properties are listed in upper camel case "
 		l.LogWithFields(ctx).Error(errorMessage)
 		common.GeneralError(http.StatusBadRequest, response.PropertyUnknown,
 			errorMessage, []interface{}{invalidProperties}, taskInfo)
+		return
 	}
 
 	// spliting the uuid and system id
@@ -91,6 +94,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 		common.GeneralError(http.StatusNotFound, response.ResourceNotFound,
 			gerr.Error(), []interface{}{"ComputerSystem", "/redfish/v1/Systems/" +
 				req.SystemID}, taskInfo)
+		return
 	}
 	decryptedPasswordByte, err := p.DevicePassword(target.Password)
 	if err != nil {
@@ -98,6 +102,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 		errorMessage := "error while trying to decrypt device password: " + err.Error()
 		common.GeneralError(http.StatusInternalServerError, response.InternalError,
 			errorMessage, nil, taskInfo)
+		return
 	}
 
 	target.Password = decryptedPasswordByte
@@ -106,6 +111,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 		errorMessage := "error while trying to get plugin details"
 		common.GeneralError(http.StatusInternalServerError,
 			response.InternalError, errorMessage, nil, nil)
+		return
 	}
 
 	var contactRequest scommon.PluginContactRequest
@@ -126,6 +132,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 		if err != nil {
 			common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage,
 				err.Error(), nil, nil)
+			return
 		}
 		contactRequest.Token = token
 	} else {
@@ -158,6 +165,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 			common.GeneralError(http.StatusInternalServerError, response.InternalError,
 				errMsg, nil, taskInfo)
 		}
+		return
 	}
 
 	if getResponse.StatusCode == http.StatusAccepted {
@@ -172,6 +180,7 @@ func (p *PluginContact) ComputerSystemReset(ctx context.Context,
 	if err != nil {
 		common.GeneralError(http.StatusInternalServerError,
 			response.InternalError, err.Error(), nil, taskInfo)
+		return
 	}
 	smodel.AddSystemResetInfo(ctx, "/redfish/v1/Systems/"+req.SystemID,
 		resetCompSys.ResetType)

--- a/svc-systems/systems/reset_test.go
+++ b/svc-systems/systems/reset_test.go
@@ -20,14 +20,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"reflect"
 	"testing"
-
-	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
-	"github.com/stretchr/testify/assert"
 
 	"github.com/ODIM-Project/ODIM/lib-utilities/common"
 	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	"github.com/ODIM-Project/ODIM/lib-utilities/errors"
 	systemsproto "github.com/ODIM-Project/ODIM/lib-utilities/proto/systems"
 	"github.com/ODIM-Project/ODIM/lib-utilities/response"
 	"github.com/ODIM-Project/ODIM/svc-systems/scommon"
@@ -282,11 +279,11 @@ func TestPluginContact_ComputerSystemReset(t *testing.T) {
 	ctx := mockContext()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.p.ComputerSystemReset(ctx, tt.args.req, "task123453", "admin"); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("PluginContact.ComputerSystemReset() = %v, want %v", got, tt.want)
-			}
+			tt.p.ComputerSystemReset(ctx, tt.args.req, "task123453", "admin")
 		})
 	}
+
+	// expected internal server error
 	req := systemsproto.ComputerSystemResetRequest{
 		SystemID:    "24b243cf-f1e3-5318-92d9-2d6737d6b0b.1",
 		RequestBody: []byte(`{"ResetType": "ForceRestart"}`),
@@ -294,8 +291,9 @@ func TestPluginContact_ComputerSystemReset(t *testing.T) {
 	JSONUnMarshal = func(data []byte, v interface{}) error {
 		return &errors.Error{}
 	}
-	resp := pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
-	assert.Equal(t, http.StatusInternalServerError, int(resp.StatusCode), "Status code should be StatusInternalServerError")
+	pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
+
+	// bad request
 	req = systemsproto.ComputerSystemResetRequest{
 		SystemID:    "24b243cf-f1e3-5318-92d9-2d6737d6b0b.1",
 		RequestBody: []byte(`{"resetType": "ForceRestart"}`),
@@ -303,23 +301,23 @@ func TestPluginContact_ComputerSystemReset(t *testing.T) {
 	JSONUnMarshal = func(data []byte, v interface{}) error {
 		return nil
 	}
-	resp = pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
-	assert.Equal(t, http.StatusBadRequest, int(resp.StatusCode), "Status code should be StatusBadRequest")
+	pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
 
+	// internal server error
 	RequestParamsCaseValidatorFunc = func(rawRequestBody []byte, reqStruct interface{}) (string, error) {
 		return "", &errors.Error{}
 	}
-	resp = pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
-	assert.Equal(t, http.StatusInternalServerError, int(resp.StatusCode), "Status code should be StatusInternalServerError")
+	pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
 
 	RequestParamsCaseValidatorFunc = func(rawRequestBody []byte, reqStruct interface{}) (string, error) {
 		return "", nil
 	}
+
 	// Invalid PreferredAuthType
 	StringsEqualFold = func(s, t string) bool {
 		return true
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
@@ -327,29 +325,27 @@ func TestPluginContact_ComputerSystemReset(t *testing.T) {
 		SystemID:    "7a2c6100-67da-5fd6-ab82-6870d29c7279.1",
 		RequestBody: []byte(`{"ResetType": "ForceRestart"}`),
 	}
-	resp = pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
-	assert.NotNil(t, resp, "Response Should have error")
+	pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
 
 	//Invalid ContactPlugin
 	StringsEqualFold = func(s, t string) bool {
 		return false
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data1 []byte, data2 string, data3 string, data4 scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
-	resp = pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
-	assert.NotNil(t, resp, "Response Should have error")
+	pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
 
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) ([]byte, string, scommon.ResponseStatus, error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) ([]byte, string, string, scommon.ResponseStatus, error) {
 		return scommon.ContactPlugin(ctx, req, errorMessage)
 	}
+
 	// Invalid Json
 	JSONUnmarshalFunc = func(data []byte, v interface{}) error {
 		return &errors.Error{}
 	}
-	resp = pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
-	assert.Equal(t, http.StatusInternalServerError, int(resp.StatusCode), "Status code should be StatusInternalServerError")
+	pluginContact.ComputerSystemReset(ctx, &req, "task123453", "admin")
 
 	JSONUnmarshalFunc = func(data []byte, v interface{}) error {
 		return json.Unmarshal(data, v)

--- a/svc-systems/systems/storage.go
+++ b/svc-systems/systems/storage.go
@@ -160,7 +160,7 @@ func (e *ExternalInterface) CreateVolume(ctx context.Context, req *systemsproto.
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, getResponse, err := scommon.ContactPlugin(ctx, contactRequest, "error while creating session with the plugin: ")
+		_, token, _, getResponse, err := scommon.ContactPlugin(ctx, contactRequest, "error while creating session with the plugin: ")
 
 		if err != nil {
 			return common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage, err.Error(), nil, nil)
@@ -179,7 +179,7 @@ func (e *ExternalInterface) CreateVolume(ctx context.Context, req *systemsproto.
 	contactRequest.DeviceInfo = target
 	contactRequest.OID = fmt.Sprintf("/ODIM/v1/Systems/%s/Storage/%s/Volumes", requestData[1], req.StorageInstance)
 
-	body, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating a volume: ")
+	body, _, _, getResponse, err := ContactPluginFunc(ctx, contactRequest, "error while creating a volume: ")
 	if err != nil {
 		resp.StatusCode = getResponse.StatusCode
 		json.Unmarshal(body, &resp.Body)
@@ -443,7 +443,7 @@ func (e *ExternalInterface) DeleteVolume(ctx context.Context, req *systemsproto.
 			"Password": string(plugin.Password),
 		}
 		contactRequest.OID = "/ODIM/v1/Sessions"
-		_, token, getResponse, err := scommon.ContactPlugin(ctx, contactRequest, "error while creating session with the plugin: ")
+		_, token, _, getResponse, err := scommon.ContactPlugin(ctx, contactRequest, "error while creating session with the plugin: ")
 
 		if err != nil {
 			return common.GeneralError(getResponse.StatusCode, getResponse.StatusMessage, err.Error(), nil, nil)
@@ -467,7 +467,7 @@ func (e *ExternalInterface) DeleteVolume(ctx context.Context, req *systemsproto.
 	contactRequest.DeviceInfo = target
 	contactRequest.OID = fmt.Sprintf("/ODIM/v1/Systems/%s/Storage/%s/Volumes/%s", requestData[1], req.StorageInstance, req.VolumeID)
 
-	body, _, getResponse, err := scommon.ContactPlugin(ctx, contactRequest, "error while deleting a volume: ")
+	body, _, _, getResponse, err := scommon.ContactPlugin(ctx, contactRequest, "error while deleting a volume: ")
 	if err != nil {
 		resp.StatusCode = getResponse.StatusCode
 		json.Unmarshal(body, &resp.Body)

--- a/svc-systems/systems/storage_test.go
+++ b/svc-systems/systems/storage_test.go
@@ -380,7 +380,7 @@ func TestPluginContact_CreateVolume(t *testing.T) {
 	StringsEqualFold = func(s, t string) bool {
 		return false
 	}
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data []byte, data1 string, status scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data []byte, data1 string, data2 string, status scommon.ResponseStatus, err error) {
 		err = &errors.Error{}
 		return
 	}
@@ -395,7 +395,7 @@ func TestPluginContact_CreateVolume(t *testing.T) {
 	resp = storage.CreateVolume(ctx, &req)
 	assert.True(t, true, "Error: Plugin Contact")
 
-	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data []byte, data1 string, status scommon.ResponseStatus, err error) {
+	ContactPluginFunc = func(ctx context.Context, req scommon.PluginContactRequest, errorMessage string) (data []byte, data1 string, data2 string, status scommon.ResponseStatus, err error) {
 		return scommon.ContactPlugin(ctx, req, errorMessage)
 	}
 	JSONUnmarshalFunc = func(data []byte, v interface{}) error {

--- a/svc-task/main.go
+++ b/svc-task/main.go
@@ -109,8 +109,7 @@ func main() {
 	// TODO: configure the job queue size
 	jobQueueSize := 10
 	tmb.TaskEventRecvQueue, tmb.TaskEventProcQueue = common.CreateJobQueue(jobQueueSize)
-	// worker count should be one to keep the temporal order of the task events
-	common.RunReadWorkers(tmb.TaskEventProcQueue, task.ProcessTaskEvents, 1)
+	common.RunReadWorkers(tmb.TaskEventProcQueue, task.ProcessTaskEvents, 5)
 	go tmb.SubscribeTaskEventsQueue(common.TaskEventsTopic)
 
 	tick := &tmodel.Tick{

--- a/svc-task/main.go
+++ b/svc-task/main.go
@@ -30,7 +30,7 @@ import (
 	auth "github.com/ODIM-Project/ODIM/svc-task/tauth"
 	"github.com/ODIM-Project/ODIM/svc-task/tcommon"
 	"github.com/ODIM-Project/ODIM/svc-task/thandle"
-	"github.com/ODIM-Project/ODIM/svc-task/tmessagebus"
+	tmb "github.com/ODIM-Project/ODIM/svc-task/tmessagebus"
 	"github.com/ODIM-Project/ODIM/svc-task/tmodel"
 	"github.com/ODIM-Project/ODIM/svc-task/tqueue"
 )
@@ -99,12 +99,19 @@ func main() {
 	task.UpdateTaskQueue = tqueue.EnqueueTask
 	task.PersistTaskModel = tmodel.PersistTask
 	task.ValidateTaskUserNameModel = tmodel.ValidateTaskUserName
-	task.PublishToMessageBus = tmessagebus.Publish
+	task.PublishToMessageBus = tmb.Publish
 	thandle.TaskCollection = thandle.TaskCollectionData{
 		TaskCollection: make(map[string]int32),
 		Lock:           sync.Mutex{},
 	}
 	taskproto.RegisterGetTaskServiceServer(services.ODIMService.Server(), task)
+
+	// TODO: configure the job queue size
+	jobQueueSize := 10
+	tmb.TaskEventRecvQueue, tmb.TaskEventProcQueue = common.CreateJobQueue(jobQueueSize)
+	// worker count should be one to keep the temporal order of the task events
+	common.RunReadWorkers(tmb.TaskEventProcQueue, task.ProcessTaskEvents, 1)
+	go tmb.SubscribeTaskEventsQueue(common.TaskEventsTopic)
 
 	tick := &tmodel.Tick{
 		Ticker: time.NewTicker(time.Duration(config.Data.TaskQueueConf.DBCommitInterval) * time.Microsecond),

--- a/svc-task/main.go
+++ b/svc-task/main.go
@@ -110,7 +110,7 @@ func main() {
 	jobQueueSize := 10
 	tmb.TaskEventRecvQueue, tmb.TaskEventProcQueue = common.CreateJobQueue(jobQueueSize)
 	common.RunReadWorkers(tmb.TaskEventProcQueue, task.ProcessTaskEvents, 5)
-	go tmb.SubscribeTaskEventsQueue(common.TaskEventsTopic)
+	go tmb.SubscribeTaskEventsQueue(config.Data.MessageBusConf.OdimTaskEventsQueue)
 
 	tick := &tmodel.Tick{
 		Ticker: time.NewTicker(time.Duration(config.Data.TaskQueueConf.DBCommitInterval) * time.Microsecond),

--- a/svc-task/thandle/thandle.go
+++ b/svc-task/thandle/thandle.go
@@ -1146,3 +1146,25 @@ func (ts *TasksRPC) updateTaskUtil(ctx context.Context, taskID string, taskState
 	}
 	return err
 }
+
+func (ts *TasksRPC) ProcessTaskEvents(data interface{}) bool {
+	event := data.(common.TaskEvent)
+	pluginTask, err := tmodel.GetPluginTaskInfo(event.TaskID)
+	if err != nil {
+		l.Log.Error("error while processing task event", err.Error())
+		return false
+	}
+
+	l.Log.Debugf("Received task event from plugin %v for odim task %s",
+		event, pluginTask.OdimTaskID)
+
+	err = ts.updateTaskUtil(context.TODO(), pluginTask.OdimTaskID,
+		event.TaskState, event.TaskStatus, event.PercentComplete,
+		nil, event.EndTime)
+	if err != nil {
+		l.Log.Error("failed to update task: error while updating task: " +
+			err.Error())
+		return false
+	}
+	return true
+}

--- a/svc-task/thandle/thandle.go
+++ b/svc-task/thandle/thandle.go
@@ -941,6 +941,13 @@ func (ts *TasksRPC) updateTaskUtil(ctx context.Context, taskID string, taskState
 	if err != nil {
 		return fmt.Errorf("error while retrieving the task details from db: " + err.Error())
 	}
+
+	if task.PercentComplete > percentComplete {
+		return fmt.Errorf("The task with id %s is already updated with %d percent complete."+
+			"skipping the update request with the percent complete %d", taskID,
+			task.PercentComplete, percentComplete)
+	}
+
 	//If the task is already in cancelled state, then updates are not allowed to it.
 	if task.TaskState == common.Cancelled {
 		return fmt.Errorf(common.Cancelled)
@@ -1155,12 +1162,21 @@ func (ts *TasksRPC) ProcessTaskEvents(data interface{}) bool {
 		return false
 	}
 
-	l.Log.Debugf("Received task event from plugin %v for odim task %s",
-		event, pluginTask.OdimTaskID)
+	l.Log.Debugf("Received task event from plugin for odim task %s, "+
+		"plugin taskID: %s, taskState: %s, taskStatus: %s, percentComplete: %d"+
+		"status code: %d: response body: %s, end time: %v",
+		pluginTask.OdimTaskID, event.TaskID, event.TaskState, event.TaskStatus,
+		event.PercentComplete, event.StatusCode, string(event.ResponseBody),
+		event.EndTime)
+
+	payLoad := &taskproto.Payload{
+		StatusCode:   event.StatusCode,
+		ResponseBody: event.ResponseBody,
+	}
 
 	err = ts.updateTaskUtil(context.TODO(), pluginTask.OdimTaskID,
 		event.TaskState, event.TaskStatus, event.PercentComplete,
-		nil, event.EndTime)
+		payLoad, event.EndTime)
 	if err != nil {
 		l.Log.Error("failed to update task: error while updating task: " +
 			err.Error())

--- a/svc-task/tmessagebus/consume.go
+++ b/svc-task/tmessagebus/consume.go
@@ -1,0 +1,67 @@
+//(C) Copyright [2023] Hewlett Packard Enterprise Development LP
+//
+//Licensed under the Apache License, Version 2.0 (the "License"); you may
+//not use this file except in compliance with the License. You may obtain
+//a copy of the License at
+//
+//    http:#www.apache.org/licenses/LICENSE-2.0
+//
+//Unless required by applicable law or agreed to in writing, software
+//distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+//WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+//License for the specific language governing permissions and limitations
+// under the License
+
+package tmessagebus
+
+import (
+	"encoding/json"
+
+	dc "github.com/ODIM-Project/ODIM/lib-messagebus/datacommunicator"
+	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+	l "github.com/ODIM-Project/ODIM/lib-utilities/logs"
+)
+
+var (
+	TaskEventRecvQueue chan<- interface{}
+	TaskEventProcQueue <-chan interface{}
+)
+
+// SubscribeCtrlMsgQueue creates a consumer for the kafka topic
+func SubscribeTaskEventsQueue(topicName string) {
+	config.TLSConfMutex.RLock()
+	MessageBusConfigFilePath := config.Data.MessageBusConf.MessageBusConfigFilePath
+	messagebusType := config.Data.MessageBusConf.MessageBusType
+	config.TLSConfMutex.RUnlock()
+	// connecting to messagbus
+	k, err := dc.Communicator(messagebusType, MessageBusConfigFilePath, topicName)
+	if err != nil {
+		l.Log.Error("Unable to connect to kafka" + err.Error())
+		return
+	}
+	// subscribe from message bus
+	if err := k.Accept(consumeTaskEvents); err != nil {
+		l.Log.Error(err.Error())
+		return
+	}
+}
+
+// consumeCtrlMsg consume control messages
+func consumeTaskEvents(event interface{}) {
+	data, _ := json.Marshal(&event)
+	var eventData common.Events
+	err := json.Unmarshal(data, &eventData)
+	if err != nil {
+		l.Log.Error("Error while consuming task events", err)
+		return
+	}
+
+	var taskEvent common.TaskEvent
+	err = json.Unmarshal(eventData.Request, &taskEvent)
+	if err != nil {
+		l.Log.Error("Error while consuming task events", err)
+		return
+	}
+	TaskEventRecvQueue <- taskEvent
+}

--- a/svc-task/tmessagebus/consume.go
+++ b/svc-task/tmessagebus/consume.go
@@ -28,7 +28,7 @@ var (
 	TaskEventProcQueue <-chan interface{}
 )
 
-// SubscribeCtrlMsgQueue creates a consumer for the kafka topic
+// SubscribeTaskEventsQueue creates a consumer for the task event topic
 func SubscribeTaskEventsQueue(topicName string) {
 	config.TLSConfMutex.RLock()
 	MessageBusConfigFilePath := config.Data.MessageBusConf.MessageBusConfigFilePath
@@ -47,7 +47,7 @@ func SubscribeTaskEventsQueue(topicName string) {
 	}
 }
 
-// consumeCtrlMsg consume control messages
+// consumeTaskEvents consume task event messages
 func consumeTaskEvents(event interface{}) {
 	data, _ := json.Marshal(&event)
 	var eventData common.Events

--- a/svc-task/tmessagebus/consume_test.go
+++ b/svc-task/tmessagebus/consume_test.go
@@ -1,0 +1,83 @@
+// (C) Copyright [2020] Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+package tmessagebus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ODIM-Project/ODIM/lib-utilities/common"
+	"github.com/ODIM-Project/ODIM/lib-utilities/config"
+)
+
+func TestSubscribeTaskEventsQueue(t *testing.T) {
+	err := config.SetUpMockConfig(t)
+	if err != nil {
+		t.Fatalf("fatal: error while trying to collect mock db config: %v", err)
+		return
+	}
+	type args struct {
+		topicName string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "subscribe task event topic",
+			args: args{
+				topicName: "task-event-topic",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SubscribeTaskEventsQueue(tt.args.topicName)
+		})
+	}
+}
+
+func Test_consumeTaskEvents(t *testing.T) {
+	err := config.SetUpMockConfig(t)
+	if err != nil {
+		t.Fatalf("fatal: error while trying to collect mock db config: %v", err)
+		return
+	}
+	TaskEventRecvQueue, TaskEventProcQueue = common.CreateJobQueue(1)
+	type args struct {
+		event interface{}
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "consume task event",
+			args: args{
+				event: common.TaskEvent{
+					TaskID:          "sample_task_id",
+					TaskState:       common.New,
+					TaskStatus:      common.OK,
+					PercentComplete: 30,
+					EndTime:         time.Now(),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumeTaskEvents(tt.args.event)
+		})
+	}
+}

--- a/svc-task/tmodel/tmodel.go
+++ b/svc-task/tmodel/tmodel.go
@@ -315,7 +315,15 @@ func (tick *Tick) ProcessTaskQueue(queue *chan *Task, conn *db.Conn) {
 
 		if task != nil {
 			saveID := Table + ":" + task.ID
-			tasks[saveID] = task
+			if data, ok := tasks[saveID]; ok {
+				t := data.(*Task)
+				if t.PercentComplete < task.PercentComplete {
+					tasks[saveID] = task
+				}
+			} else {
+				tasks[saveID] = task
+			}
+
 			if (task.TaskState == "Completed" || task.TaskState == "Exception") && task.ParentID == "" {
 				completedTasks[saveID] = 1
 			}

--- a/svc-task/tmodel/tmodel.go
+++ b/svc-task/tmodel/tmodel.go
@@ -221,6 +221,27 @@ func GetAllTaskKeys(ctx context.Context) ([]string, error) {
 	return taskKeys, nil
 }
 
+func GetPluginTaskInfo(taskID string) (*common.PluginTask, error) {
+	errPrefix := "error while trying to get plugin task info"
+	pluginTask := new(common.PluginTask)
+	connPool, err := common.GetDBConnection(common.InMemory)
+	if err != nil {
+		return nil, fmt.Errorf(errPrefix+
+			": error while trying to get DB connection: %v", err.Error())
+	}
+
+	taskData, err := connPool.Read("PluginTask", taskID)
+	if err != nil {
+		return nil, fmt.Errorf(errPrefix+
+			": error while trying to read from DB: %v", err.Error())
+	}
+
+	if errs := json.Unmarshal([]byte(taskData), pluginTask); errs != nil {
+		return nil, fmt.Errorf(errPrefix+": %v", errs)
+	}
+	return pluginTask, nil
+}
+
 //Transaction - is for performing atomic oprations using optimitic locking
 func Transaction(ctx context.Context, key string, cb func(context.Context, string) error) error {
 	connPool, err := common.GetDBConnection(common.InMemory)


### PR DESCRIPTION
**Changes**
* reset computer system code is updated to save plugin task info in DB
* received plugin instance IP in the header of the plugin response
*  task events are subscribed and consumed
* odim tasks are updated based on task events
* updated unit tests